### PR TITLE
fixed scrolling issue in asset readings (specific iOS devices)

### DIFF
--- a/src/app/asset-readings/assets/assets.component.css
+++ b/src/app/asset-readings/assets/assets.component.css
@@ -1,0 +1,29 @@
+.media-content{
+   overflow: hidden;
+}
+
+table.readings-scroll {
+    overflow-x: auto;
+    display: block;
+}
+
+@media screen and (max-width: 769px) {
+    table.readings-scroll {
+        height: 300px;
+    }
+}
+@media screen and (min-width: 1024px) {
+    table.readings-scroll {
+        height: 350px;
+    }
+}
+@media screen and (min-width: 1216px) {
+    table.readings-scroll {
+        height: 400px;
+    }
+}
+@media screen and (min-width: 1408px) {
+    table.readings-scroll {
+        height: 650px;
+    }
+}

--- a/src/app/asset-readings/assets/assets.component.html
+++ b/src/app/asset-readings/assets/assets.component.html
@@ -1,14 +1,17 @@
 <div class="container is-fluid">
-  <ng-progress [positionUsing]="'marginLeft'" [minimum]="0.15" [maximum]="1"
-            [speed]="200" [showSpinner]="true" [direction]="'leftToRightIncreased'"
-            [color]="'#1B95E0'" [trickleSpeed]="300" [thick]="true" [ease]="'linear'">
+  <ng-progress [positionUsing]="'marginLeft'" [minimum]="0.15" [maximum]="1" [speed]="200" [showSpinner]="true" [direction]="'leftToRightIncreased'"
+    [color]="'#1B95E0'" [trickleSpeed]="300" [thick]="true" [ease]="'linear'">
   </ng-progress>
-  <div class="tile">
-    <div class="tile is-parent">
-      <article class="tile is-child box">
-        <h5 class="title is-5">
-          Assets
-        </h5>
+  <div class="card">
+    <header class="card-header">
+      <div class="card-content">
+        <div class="media-content">
+          <h5 class="title is-5">Assets</h5>
+        </div>
+      </div>
+    </header>
+    <div class="card-content">
+      <div class="content">
         <table class="table is-striped is-narrow scroll is-responsive">
           <thead>
             <tr>
@@ -37,16 +40,19 @@
             </tr>
             <tbody>
         </table>
-      </article>
+      </div>
     </div>
   </div>
-
-  <div class="tile">
-    <div class="tile is-parent">
-      <article class="tile is-child box">
-        <h5 class="title is-5">
-           Asset Readings
-        </h5>
+  <div class="card">
+    <header class="card-header">
+      <div class="card-content">
+        <div class="media-content">
+          <h5 class="title is-5">Asset Readings</h5>
+        </div>
+      </div>
+    </header>
+    <div class="card-content">
+      <div class="content">
         <div class="columns">
           <div class="column">
             <div class="select is-fullwidth">
@@ -65,7 +71,7 @@
             <p *ngIf='isInvalidOffset' class='help is-danger'>Offset must be in range 1 - 2147483647</p>
           </div>
         </div>
-        <table class="table is-striped is-narrow scroll is-responsive">
+        <table *ngIf="isSummary" class="table is-striped is-narrow readings-scroll is-responsive">
           <thead>
             <tr>
               <th>Asset</th>
@@ -107,12 +113,11 @@
         </table>
         <app-asset-summary></app-asset-summary>
         <app-chart-modal></app-chart-modal>
-        <div *ngIf='totalPagesCount > 1'>
-          <app-pagination [count]='recordCount' [page]="page" [perPage]='limit' [totalPage]='totalPagesCount' (goPrev)="onPrev()" (goNext)="onNext()"
-            (goFirst)="onFirst()" (goLast)="onLast()" (goPage)="goToPage($event)">
-          </app-pagination>
-        </div>
-      </article>
+      </div>
+      <div *ngIf='totalPagesCount > 1'>
+        <app-pagination [count]='recordCount' [page]="page" [perPage]='limit' [totalPage]='totalPagesCount' (goPrev)="onPrev()" (goNext)="onNext()"
+          (goFirst)="onFirst()" (goLast)="onLast()" (goPage)="goToPage($event)">
+        </app-pagination>
+      </div>
     </div>
   </div>
-</div>


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed Vertical scrolling in `Asset & Readings` (iPad issue when going to next page through pagination) 

## Are there changes in behavior for the user?

Now vertical scroll bar will display in `Asset Readings` section

## Related issue number
None

## Checklist

- [x] Code is well written w.r.t. best practices and proper comments
- [ ] Unit tests for the changes exist
- [ ] e2e tests for the changes exist
- [ ] Documentation reflects the changes including changelog
- [x] Build works with nginx-light deployment
- [x] Build works with Docker, if any change on docker related config files; **NA**


