### PR TITLE
debian packager added for any architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Debian build packages
+packages/build/

--- a/make_deb
+++ b/make_deb
@@ -57,7 +57,17 @@ do
   esac
 done
 
-version=`jq -r '.version' package.json`
+# OS Type
+os=$(uname)
+echo "Operating System Type ${os}"
+
+if [[ ${os} == "Darwin" ]]
+then
+  echo "Script is not compatible with macOS"
+  exit 1
+fi
+
+version=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[" ,]//g'`
 BUILD_ROOT="${GIT_ROOT}/packages/build"
 
 # Final package name
@@ -96,9 +106,9 @@ mkdir "${package_name}"
 echo -n "Populating the package and updating version file..."
 cd "${package_name}"
 cp -R ${GIT_ROOT}/packages/Debian/* .
-sed -i "s/Version: ${version}/Version: $version/g" DEBIAN/control
+sed -i "s/Version: 1.2.0/Version: ${version}/g" DEBIAN/control
 
-echo "Copy build artifacts to nginx webroot directory"
+echo "Copy build artifacts for nginx webroot directory"
 mkdir -p var/www/html
 cd var/www/html
 cp -R ${GIT_ROOT}/dist/* .

--- a/make_deb
+++ b/make_deb
@@ -1,0 +1,124 @@
+#!/bin/bash
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+##
+## Author: Ashish Jabble
+##
+
+set -e
+
+GIT_ROOT=`pwd`    # The script must be executed from the root git directory
+usage="$(basename "$0") [clean|cleanall]
+This script is used to create the Debian package of foglamp-gui
+
+Arguments:
+ clean    - Remove all the old versions saved in format .XXXX
+ cleanall - Remove all the versions, including the last one"
+
+for i in "$@"
+do
+  case "$i" in
+      clean)
+          echo -n "Cleaning the build folder from older versions..."
+          find "${GIT_ROOT}/packages/build" -maxdepth 1 | grep '.*\.[0-9][0-9][0-9][0-9]' | xargs rm -rf
+          echo "Done."
+
+          exit 0
+          ;;
+      cleanall)
+          if [ -d "${GIT_ROOT}/packages/build" ]; then
+            echo -n "Cleaning the build folder..."
+            rm -rf ${GIT_ROOT}/packages/build/*
+            echo "Done."
+          else
+            echo "No build folder, skipping cleanall"
+          fi
+
+          exit 0
+          ;;
+      *)
+          echo "${usage}"
+          exit 1
+          ;;
+  esac
+done
+
+version=`jq -r '.version' package.json`
+BUILD_ROOT="${GIT_ROOT}/packages/build"
+
+# Final package name
+package_name="foglamp-gui-${version}"
+
+# Print the summary of findings
+echo "The package root directory is         : ${GIT_ROOT}"
+echo "The FogLAMP gui version is            : ${version}"
+echo "The Package will be built in          : ${BUILD_ROOT}"
+echo "The package name is                   : ${package_name}"
+echo
+
+# Prepare build artifacts
+rm -rf ${GIT_ROOT}/dist
+./build.sh
+
+# Create the package directory. If a directory with the same name exists,
+# it is copied with a version number.
+
+# First, create the BUILD_ROOT folder, if necessary
+if [ ! -L "${BUILD_ROOT}" -a ! -d "${BUILD_ROOT}" ]; then
+    mkdir -p "${BUILD_ROOT}"
+fi
+
+cd "${BUILD_ROOT}"
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.%04d" "${existing_pkgs}")
+if [ -d "${package_name}" ]; then
+    echo "Saving the old working environment as ${new_stored_pkg}"
+    mv "${package_name}" "${new_stored_pkg}"
+fi
+mkdir "${package_name}"
+
+# Populate the package directory with Debian files
+echo -n "Populating the package and updating version file..."
+cd "${package_name}"
+cp -R ${GIT_ROOT}/packages/Debian/* .
+sed -i "s/Version: ${version}/Version: $version/g" DEBIAN/control
+
+echo "Copy build artifacts to nginx webroot directory"
+mkdir -p var/www/html
+cd var/www/html
+cp -R ${GIT_ROOT}/dist/* .
+echo "Done."
+
+# Build the package
+cd "${BUILD_ROOT}"
+
+# Save the old versions
+existing_pkgs=`find . -maxdepth 1 -name "${package_name}.deb.????" | wc -l`
+existing_pkgs=$((existing_pkgs+1))
+new_stored_pkg=$(printf "${package_name}.deb.%04d" "${existing_pkgs}")
+
+if [ -e "${package_name}.deb" ]; then
+    echo "Saving the old package as ${new_stored_pkg}"
+    mv "${package_name}.deb" "${new_stored_pkg}"
+fi
+
+echo "Building the new package..."
+dpkg-deb --build ${package_name}
+echo "Building Complete."
+
+exit 0

--- a/packages/Debian/DEBIAN/control
+++ b/packages/Debian/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: foglamp-gui
+Version: 1.2.0
+Section: devel
+Priority: optional
+Architecture: all
+Depends: nginx-light
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: FogLAMP GUI

--- a/packages/Debian/DEBIAN/postinst
+++ b/packages/Debian/DEBIAN/postinst
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @postinst DEBIAN/postinst
+## This script is used to execute post installation tasks.
+##
+## Author: Ashish Jabble
+##
+##--------------------------------------------------------------------
+
+set -e
+
+set_files_ownership () {
+    chown -R root:root /var/www/html/*
+}
+
+start_nginx_service () {
+    sudo service nginx start
+}
+
+set_files_ownership
+start_nginx_service
+sudo service nginx status | grep "Active:"

--- a/packages/Debian/DEBIAN/preinst
+++ b/packages/Debian/DEBIAN/preinst
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2018 Dianomic Systems
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @preinst DEBIAN/preinst
+## This script is used to execute pre installation tasks.
+##
+## Author: Ashish Jabble
+##
+##--------------------------------------------------------------------
+
+
+echo "Installing FogLAMP GUI"
+stop_nginx_service () {
+    sudo service nginx stop
+}
+
+stop_nginx_service


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What do these changes do?
<!-- Please give a short brief about these changes. -->
It will create a debian package for any architecture by following command:

`./make_deb`

You can find debian package inside `packages/build` dir


## Are there changes in behavior for the user?
NO
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
NO
## Checklist

- [x] Code is well written w.r.t. best practices and proper comments
- [x] Unit tests for the changes exist  -- NOT APPLICABLE
- [x] e2e tests for the changes exist  -- NOT APPLICABLE
- [ ] Documentation reflects the changes including changelog
- [x] Build works with nginx-light deployment
- [x] Build works with Docker, if any change on docker related config files -- NOT APPLICABLE


## Check Contents of debian package and Install

`sudo dpkg -c foglamp-gui-1.2.0.deb`

> should have `./var/www/html/` with js, css etc files.

`sudo dpkg -i foglamp-gui-1.2.0.deb`

```
(Reading database ... <n> files and directories currently installed.)
Preparing to unpack foglamp-gui-1.2.0.deb ...
Installing FogLAMP GUI
Unpacking foglamp-gui (1.2.0) ...
Setting up foglamp-gui (1.2.0) ...
   Active: active (running) since Fri 2018-06-22 11:49:24 UTC; 91ms ago
```

> if `nginx-light` is not installed.

```
(Reading database ... <n> files and directories currently installed.)
Preparing to unpack foglamp-gui-1.2.0.deb ...
Installing FogLAMP GUI
Failed to stop nginx.service: Unit nginx.service not loaded.
dpkg: error processing archive foglamp-gui-1.2.0.deb (--install):
 subprocess new pre-installation script returned error exit status 5
Errors were encountered while processing:
 foglamp-gui-1.2.0.deb
```

> Install nginx-light if not installed with `sudo apt install nginx-light`

