### PR TITLE
Fixed download support bundle issue in mandatory mode [FOGL-1309]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@
 * Input mask external lib
 
 #### Bug Fixes
+* Fixed download support bundle issue in authentication required  mode
 
 #### Known Issues
 

--- a/changelog.md
+++ b/changelog.md
@@ -16,7 +16,7 @@
 * Input mask external lib
 
 #### Bug Fixes
-* Fixed download support bundle issue in authentication required  mode
+* [FIXED] Support bundles download when authentication is mandatory
 
 #### Known Issues
 

--- a/src/app/components/core/support/support.component.html
+++ b/src/app/components/core/support/support.component.html
@@ -22,7 +22,7 @@
           <tr *ngFor="let bundle of bundlesData">
             <td>{{ bundle }}</td>
             <td>
-              <a href="{{ supportUrl }}/{{ bundle }}" target="_blank" class="button is-text">
+              <a (click)="downloadBundle(bundle)" target="_blank" class="button is-text">
                 download
               </a>
             </td>

--- a/src/app/components/core/support/support.component.html
+++ b/src/app/components/core/support/support.component.html
@@ -22,7 +22,7 @@
           <tr *ngFor="let bundle of bundlesData">
             <td>{{ bundle }}</td>
             <td>
-              <a (click)="downloadBundle(bundle)" target="_blank" class="button is-text">
+              <a (click)="downloadBundle(bundle)" class="button is-text">
                 download
               </a>
             </td>

--- a/src/app/components/core/support/support.component.ts
+++ b/src/app/components/core/support/support.component.ts
@@ -1,3 +1,4 @@
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { NgProgress } from 'ngx-progressbar';
 
@@ -10,10 +11,10 @@ import { AlertService, SupportService } from '../../../services';
 })
 export class SupportComponent implements OnInit {
   public bundlesData = [];
-  public supportUrl = this.supportBundleService.SUPPORT_BUNDLE_URL;
-
-  constructor(private supportBundleService: SupportService, public ngProgress: NgProgress, private alertService: AlertService) { }
-
+  constructor(private supportBundleService: SupportService,
+    public ngProgress: NgProgress,
+    private alertService: AlertService,
+    private http: HttpClient) { }
 
   ngOnInit() {
     this.getBundles();
@@ -54,6 +55,18 @@ export class SupportComponent implements OnInit {
             this.alertService.error(error.statusText);
           }
         });
+  }
+
+  public async downloadBundle(bundle): Promise<void> {
+    const blob = await this.supportBundleService.downloadSupportBundle(bundle);
+    const url = window.URL.createObjectURL(blob);
+    // create a custom anchor tag
+    const a = document.createElement('a');
+    document.body.appendChild(a);
+    a.href = url;
+    a.download = bundle;
+    a.click();
+    document.body.removeChild(a);
   }
 }
 

--- a/src/app/components/core/support/support.component.ts
+++ b/src/app/components/core/support/support.component.ts
@@ -57,7 +57,6 @@ export class SupportComponent implements OnInit {
 
   public async downloadBundle(bundle): Promise<void> {
     const blob = await this.supportBundleService.downloadSupportBundle(bundle);
-    console.log(blob);
     const url = window.URL.createObjectURL(blob);
     // create a custom anchor tag
     const a = document.createElement('a');

--- a/src/app/components/core/support/support.component.ts
+++ b/src/app/components/core/support/support.component.ts
@@ -1,4 +1,3 @@
-import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { NgProgress } from 'ngx-progressbar';
 
@@ -13,8 +12,7 @@ export class SupportComponent implements OnInit {
   public bundlesData = [];
   constructor(private supportBundleService: SupportService,
     public ngProgress: NgProgress,
-    private alertService: AlertService,
-    private http: HttpClient) { }
+    private alertService: AlertService) { }
 
   ngOnInit() {
     this.getBundles();
@@ -59,12 +57,13 @@ export class SupportComponent implements OnInit {
 
   public async downloadBundle(bundle): Promise<void> {
     const blob = await this.supportBundleService.downloadSupportBundle(bundle);
+    console.log(blob);
     const url = window.URL.createObjectURL(blob);
     // create a custom anchor tag
     const a = document.createElement('a');
-    document.body.appendChild(a);
     a.href = url;
     a.download = bundle;
+    document.body.appendChild(a);
     a.click();
     document.body.removeChild(a);
   }

--- a/src/app/services/support.service.ts
+++ b/src/app/services/support.service.ts
@@ -33,7 +33,6 @@ export class SupportService {
   public async downloadSupportBundle(bundle): Promise<Blob> {
     const file = await this.http.get<Blob>(
       this.SUPPORT_BUNDLE_URL + '/' + bundle,
-      // return blob(raw data) in json format i.e. Blob(153600) {size: 153600, type: "application/x-tar"}
       { responseType: 'blob' as 'json' }).toPromise();
     return file;
   }

--- a/src/app/services/support.service.ts
+++ b/src/app/services/support.service.ts
@@ -29,9 +29,11 @@ export class SupportService {
       catchError((error: Response) => observableThrowError(error)));
   }
 
+
   public async downloadSupportBundle(bundle): Promise<Blob> {
     const file = await this.http.get<Blob>(
       this.SUPPORT_BUNDLE_URL + '/' + bundle,
+      // return blob(raw data) in json format i.e. Blob(153600) {size: 153600, type: "application/x-tar"}
       { responseType: 'blob' as 'json' }).toPromise();
     return file;
   }

--- a/src/app/services/support.service.ts
+++ b/src/app/services/support.service.ts
@@ -28,4 +28,11 @@ export class SupportService {
       map(response => response),
       catchError((error: Response) => observableThrowError(error)));
   }
+
+  public async downloadSupportBundle(bundle): Promise<Blob> {
+    const file = await this.http.get<Blob>(
+      this.SUPPORT_BUNDLE_URL + '/' + bundle,
+      { responseType: 'blob' as 'json' }).toPromise();
+    return file;
+  }
 }


### PR DESCRIPTION
FOGL-1309: foglamp-gui: Allow a way to download a support bundle file through browser GET when authentication is set to mandatory (i.e. authToken header is required)