### PR TITLE
Restricted input fields to enter only valid input type in Configuration 

### DIFF
--- a/src/app/components/core/configuration-manager/configuration-manager.component.html
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.html
@@ -41,21 +41,33 @@
               <div class="field">
                 <div class="control">
                   <p hidden="true"> {{v.value.type}} </p>
-                  <input *ngIf='isObject(v?.value?.value)' id="{{category.key.trim() + '-' + v.key.trim() | lowercase }}" class="input is-small" type="text"
-                    [value]="v?.value?.value != undefined ? (JSON.stringify(v?.value?.value)) : '' " [textContent]="v?.value?.value != undefined ? (JSON.stringify(v?.value?.value)) : '' "
-                    (input)="onTextChange(category.key.trim() + '-' + v.key.trim())" />
-
-                  <input *ngIf='!isObject(v?.value?.value)' id="{{category.key.trim() + '-' + v.key.trim() | lowercase }}" class="input is-small" type="text"
-                    [value]='v?.value?.value != undefined ? v?.value?.value : "" ' [textContent]='v?.value?.value != undefined ? v?.value?.value : "" '
-                    (input)="onTextChange(category.key.trim() + '-' + v.key.trim())" />
+                  <div class="control is-fullwidth">
+                    <form name="form" id="ngForm" #f="ngForm" novalidate>
+                      <select *ngIf="v.value.type == 'boolean'" id="{{category.key.trim() + '-' + v.key.trim() | lowercase }}" (input)="onTextChange(category.key.trim() + '-' + v.key.trim())"
+                        (focus)="oldVal=v.value.value" class="select is-fullwidth is-small" [(ngModel)]="v.value.value" name="categoryValue"
+                        #categoryValue="ngModel" (ngModelChange)="onModelChange(oldVal);">
+                        <option value="true">true</option>
+                        <option value="false">false</option>
+                      </select>
+                      <input *ngIf="v.value.type == 'string'" id="{{category.key.trim() + '-' + v.key.trim() | lowercase }}" (input)="onTextChange(category.key.trim() + '-' + v.key.trim())"
+                        (focus)="oldVal=v.value.value" type="text" class="input" name='categoryValue' [(ngModel)]="v.value.value"
+                        #categoryValue="ngModel" [textContent]='v?.value?.value != undefined ? v?.value?.value : "" ' (ngModelChange)="onModelChange(oldVal);"
+                        appAlphabetsOnly />
+                      <input *ngIf="v.value.type == 'integer'" id="{{category.key.trim() + '-' + v.key.trim() | lowercase }}" (input)="onTextChange(category.key.trim() + '-' + v.key.trim())"
+                        (focus)="oldVal=v.value.value" type="number" class="input" name='categoryValue' [(ngModel)]="v.value.value"
+                        #categoryValue="ngModel" [textContent]='v?.value?.value != undefined ? v?.value?.value : "" ' (ngModelChange)="onModelChange(oldVal);"
+                        appNumberOnly />
+                    </form>
+                  </div>
                 </div>
               </div>
               <div class="field is-grouped">
                 <div class="control">
-                  <button id="btn-save-{{category.key.trim() + '-' + v.key.trim() | lowercase}}" class="button is-small is-primary" (click)="saveConfigValue(category?.key, v?.key, v?.value?.type)">Save</button>
+                  <button id="btn-save-{{category.key.trim() + '-' + v.key.trim() | lowercase}}" type="button" (click)="saveConfigValue(category.key, v.key, v.value.type, f)"
+                    class="button is-small is-primary" form="ngForm">Save</button>
                 </div>
                 <div class="control">
-                  <button id="btn-cancel-{{category.key.trim() + '-' + v.key.trim() | lowercase}}" class="button is-small is-text hidden" (click)="restoreConfigFieldValue(category.key.trim() + '-' + v.key.trim())">Cancel</button>
+                  <button id="btn-cancel-{{category.key.trim() + '-' + v.key.trim() | lowercase}}" class="button is-small is-text hidden" (click)="restoreConfigFieldValue(category.key.trim() + '-' + v.key.trim(), f)">Cancel</button>
                 </div>
               </div>
             </div>

--- a/src/app/components/core/configuration-manager/configuration.module.ts
+++ b/src/app/components/core/configuration-manager/configuration.module.ts
@@ -8,6 +8,7 @@ import { ConfigurationManagerComponent } from '.';
 import { AddConfigItemComponent } from './add-config-item/add-config-item.component';
 import { Routes, RouterModule } from '@angular/router';
 import { AuthCheckGuard } from '../../../guards';
+import { AlphabetsOnlyDirective } from '../../../directives/alpha-only.directive';
 
 const routes: Routes = [
   {
@@ -20,7 +21,8 @@ const routes: Routes = [
 @NgModule({
   declarations: [
     ConfigurationManagerComponent,
-    AddConfigItemComponent
+    AddConfigItemComponent,
+    AlphabetsOnlyDirective
   ],
   imports: [
     FormsModule,

--- a/src/app/directives/alpha-only.directive.ts
+++ b/src/app/directives/alpha-only.directive.ts
@@ -1,0 +1,24 @@
+import { Directive, HostListener } from '@angular/core';
+
+@Directive({
+  selector: '[appAlphabetsOnly]'
+})
+export class AlphabetsOnlyDirective {
+
+  constructor() { }
+
+  @HostListener('keypress') onkeypress(e) {
+    const event = e || window.event;
+    if (event) {
+      return this.isAlphabetKey(event);
+    }
+  }
+
+  isAlphabetKey(event) {
+    const charCode = (event.which) ? event.which : event.keyCode;
+    if (charCode > 31 && (charCode < 65 || charCode > 90) && (charCode < 97 || charCode > 122)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/directives/index.ts
+++ b/src/app/directives/index.ts
@@ -1,2 +1,3 @@
 export * from './number-only.directive';
 export * from './equal-validator.directive';
+export * from './alpha-only.directive';


### PR DESCRIPTION
- Dropdown appears for boolean type field
- For `string` type of field, `numeric` value should not be entered; and
- For `numeric` type of field, `alphabetic` value should not be entered.

**NOTE:** Restriction for IPv4 and IPv6 are left to implement.