### PR TITLE
Fixed input value validation on add config item page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -10,8 +10,8 @@ import { routing } from './app.routing';
 import { AlertDialogModule } from './components/common/alert-dialog/alert-dialog.module';
 import { AlertComponent } from './components/common/alert/alert.component';
 import { ChartModule } from './components/common/chart';
-import { ShutdownModalComponent } from './components/common/shut-down/shutdown-modal.component';
 import { RestartModalComponent } from './components/common/restart-modal/restart-modal.component';
+import { ShutdownModalComponent } from './components/common/shut-down/shutdown-modal.component';
 import { BackupRestoreComponent } from './components/core/backup-restore/backup-restore.component';
 import { CertificateModule } from './components/core/certificate/certificate.module';
 import { DashboardModule } from './components/core/dashboard/dashboard.module';
@@ -22,8 +22,6 @@ import { FooterComponent } from './components/layout/footer';
 import { LoginComponent } from './components/layout/login';
 import { NavbarComponent } from './components/layout/navbar/navbar.component';
 import { SideMenuComponent } from './components/layout/side-menu/side-menu.component';
-import { InputTrimDirective } from './directives/input-trim.directive';
-import { NumberOnlyDirective } from './directives/number-only.directive';
 import { AuthCheckGuard } from './guards';
 import { PipesModule } from './pipes/pipes.module';
 import {
@@ -45,6 +43,7 @@ import {
 import { HttpsRequestInterceptor } from './services/http.request.interceptor';
 import { SharedService } from './services/shared.service';
 import { SharedModule } from './shared.module';
+import { DirectivesModule } from './directives/directives.module';
 
 export function pingServiceFactory(healthService: ServicesHealthService, sharedService: SharedService): Function {
   return () => healthService.pingService()
@@ -76,7 +75,8 @@ export function pingServiceFactory(healthService: ServicesHealthService, sharedS
     AlertDialogModule,
     CertificateModule,
     DashboardModule,
-    SharedModule
+    SharedModule,
+    DirectivesModule
   ],
   declarations: [
     AppComponent,
@@ -86,8 +86,6 @@ export function pingServiceFactory(healthService: ServicesHealthService, sharedS
     SideMenuComponent,
     NavbarComponent,
     SettingsComponent,
-    NumberOnlyDirective,
-    InputTrimDirective,
     ServiceDiscoveryComponent,
     ShutdownModalComponent,
     RestartModalComponent,

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
@@ -3,7 +3,7 @@
   <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title is-size-5">Add Configuration Item</p>
-      <button class="delete" aria-label="close" (click)="toggleModal(false)"></button>
+      <button class="delete" aria-label="close" (click)="toggleModal(false, f)"></button>
     </header>
     <section class="modal-card-body">
       <form name="form" (ngSubmit)="f.form.valid && addConfigItem(f)" #f="ngForm" id="ngForm" novalidate>
@@ -38,9 +38,9 @@
             <div class="field">
               <div class="control">
                 <div class="select is-fullwidth">
-                  <select name="type" [(ngModel)]="categoryData.type" #type="ngModel" required>
-                    <option [ngValue]="undefined" disabled>Select</option>
-                    <option [ngValue]="type" *ngFor="let type of configItemType">{{type}}</option>
+                  <select name="type" [(ngModel)]="categoryData.type" #type="ngModel" (ngModelChange)="modelChanged($event)" required>
+                    <option [value]="undefined" disabled>Select</option>
+                    <option [value]="type" *ngFor="let type of configItemType">{{type}}</option>
                   </select>
                 </div>
               </div>
@@ -49,13 +49,44 @@
           </div>
         </div>
         <div class="columns">
-          <div class="column">
+          <div *ngIf=" configType === 'TEXT'" class="column">
             <div class="field">
-              <p class="control is-fullwidth">
-                <input type="text" class="input" name="defaultValue" placeholder="default value" [(ngModel)]="categoryData.defaultValue"
-                  #defaultValue="ngModel" required trim="blur" />
-              </p>
-              <small *ngIf="f.submitted && !defaultValue.valid" class="help is-danger level-left">Default value is required</small>
+              <div class="control is-fullwidth">
+                <input type="text" class="input" name="defaultValue" #stringValue="ngModel" placeholder="default value" [(ngModel)]="string" required
+                  trim="blur" />
+              </div>
+              <small *ngIf="f.submitted && !stringValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
+            </div>
+          </div>
+          <div *ngIf="configType === 'NUMBER'" class="column">
+            <div class="field">
+              <div class="control is-fullwidth">
+                <input type="number" class="input" name="defaultValue" #numberValue="ngModel" placeholder="default value" [(ngModel)]="number"
+                  required trim="blur" appNumberOnly/>
+              </div>
+              <small *ngIf="f.submitted && !numberValue.valid" class="help is-danger level-left">Value is required|Must be an integer</small>
+            </div>
+          </div>
+          <div *ngIf="configType === 'LONG_TEXT'" class="column">
+            <div class="field">
+              <div class="control is-fullwidth">
+                <textarea row='3' type="text" class="input" name="defaultValue" #textAreaValue="ngModel" placeholder="default value" [(ngModel)]="textA"
+                  required trim="blur"></textarea>
+              </div>
+              <small *ngIf="f.submitted && !textAreaValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
+            </div>
+          </div>
+          <div *ngIf="configType === 'BOOLEAN'" class="column">
+            <div class="field">
+              <div class="control is-fullwidth">
+                <div class="select is-fullwidth">
+                  <select [(ngModel)]="boolValue" #booleanValue="ngModel" name="defaultValue" required>
+                    <option [ngValue]="true">True</option>
+                    <option [ngValue]="false">False</option>
+                  </select>
+                </div>
+              </div>
+              <small *ngIf="f.submitted && !booleanValue.valid" class="help is-danger level-left">Value is required|Must be a boolean</small>
             </div>
           </div>
         </div>

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
@@ -58,7 +58,7 @@
                 <input type="text" class="input" name="defaultValue" #stringValue="ngModel" placeholder="default value" [(ngModel)]="string" required
                   trim="blur" />
               </div>
-              <small *ngIf="f.submitted && !stringValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
+              <small *ngIf="f.submitted && !stringValue.valid" class="help is-danger level-left">Value is required | Must be an string</small>
             </div>
           </div>
           <div *ngIf="configFieldType === 'NUMBER'" class="column">
@@ -67,7 +67,7 @@
                 <input type="number" class="input" name="defaultValue" #numberValue="ngModel" placeholder="default value" [(ngModel)]="number"
                   required trim="blur" appNumberOnly/>
               </div>
-              <small *ngIf="f.submitted && !numberValue.valid" class="help is-danger level-left">Value is required|Must be an integer</small>
+              <small *ngIf="f.submitted && !numberValue.valid" class="help is-danger level-left">Value is required | Must be an integer</small>
             </div>
           </div>
           <div *ngIf="configFieldType === 'LONG_TEXT'" class="column">
@@ -76,7 +76,7 @@
                 <textarea row='3' type="text" class="input" name="defaultValue" #textAreaValue="ngModel" placeholder="default value" [(ngModel)]="textA"
                   required trim="blur"></textarea>
               </div>
-              <small *ngIf="f.submitted && !textAreaValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
+              <small *ngIf="f.submitted && !textAreaValue.valid" class="help is-danger level-left">Value is required | Must be an string</small>
               <small *ngIf="!isValidJson" class="help is-danger level-left">Invalid JSON</small>
             </div>
           </div>
@@ -85,8 +85,8 @@
               <div class="control is-fullwidth">
                 <div class="select is-fullwidth">
                   <select [(ngModel)]="boolValue" #booleanValue="ngModel" name="defaultValue" required>
-                    <option [ngValue]="true">True</option>
-                    <option [ngValue]="false">False</option>
+                    <option [ngValue]="true">true</option>
+                    <option [ngValue]="false">false</option>
                   </select>
                 </div>
               </div>

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
@@ -40,7 +40,7 @@
                 <div class="select is-fullwidth">
                   <select name="type" [(ngModel)]="categoryData.type" #type="ngModel" (ngModelChange)="modelChanged($event)" required>
                     <option [value]="undefined" disabled>Select</option>
-                    <option [value]="type" *ngFor="let type of configItemType">{{type}}</option>
+                    <option [value]="type" *ngFor="let type of configItemTypes">{{type}}</option>
                   </select>
                 </div>
               </div>
@@ -49,7 +49,7 @@
           </div>
         </div>
         <div class="columns">
-          <div *ngIf=" configType === 'TEXT'" class="column">
+          <div *ngIf="configFieldType === 'TEXT'" class="column">
             <div class="field">
               <div class="control is-fullwidth">
                 <input type="text" class="input" name="defaultValue" #stringValue="ngModel" placeholder="default value" [(ngModel)]="string" required
@@ -58,7 +58,7 @@
               <small *ngIf="f.submitted && !stringValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
             </div>
           </div>
-          <div *ngIf="configType === 'NUMBER'" class="column">
+          <div *ngIf="configFieldType === 'NUMBER'" class="column">
             <div class="field">
               <div class="control is-fullwidth">
                 <input type="number" class="input" name="defaultValue" #numberValue="ngModel" placeholder="default value" [(ngModel)]="number"
@@ -67,16 +67,17 @@
               <small *ngIf="f.submitted && !numberValue.valid" class="help is-danger level-left">Value is required|Must be an integer</small>
             </div>
           </div>
-          <div *ngIf="configType === 'LONG_TEXT'" class="column">
+          <div *ngIf="configFieldType === 'LONG_TEXT'" class="column">
             <div class="field">
               <div class="control is-fullwidth">
                 <textarea row='3' type="text" class="input" name="defaultValue" #textAreaValue="ngModel" placeholder="default value" [(ngModel)]="textA"
                   required trim="blur"></textarea>
               </div>
               <small *ngIf="f.submitted && !textAreaValue.valid" class="help is-danger level-left">Value is required|Must be an string</small>
+              <small *ngIf="!isValidJson" class="help is-danger level-left">Invalid JSON</small>
             </div>
           </div>
-          <div *ngIf="configType === 'BOOLEAN'" class="column">
+          <div *ngIf="configFieldType === 'BOOLEAN'" class="column">
             <div class="field">
               <div class="control is-fullwidth">
                 <div class="select is-fullwidth">

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.html
@@ -43,7 +43,7 @@
                 <div class="select is-fullwidth">
                   <select name="type" [(ngModel)]="categoryData.type" #type="ngModel" (ngModelChange)="modelChanged($event)" required>
                     <option [value]="undefined" disabled>Select</option>
-                    <option [value]="type" *ngFor="let type of configItemTypes">{{type}}</option>
+                    <option [value]="type.key" *ngFor="let type of configItemTypes">{{type.value}}</option>
                   </select>
                 </div>
               </div>

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -47,6 +47,7 @@ export class AddConfigItemComponent implements OnInit {
 
   public toggleModal(isOpen: Boolean, form: NgForm = null) {
     if (form != null) {
+      this.isValidJson = true;
       this.resetAddConfigItemForm(form);
     }
     const modal = <HTMLDivElement>document.getElementById('add-config-item');

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -11,14 +11,16 @@ import { AlertService, ConfigurationService } from '../../../../services';
 export class AddConfigItemComponent implements OnInit {
   public catName = '';
   public categoryData: any;
-  configItemType = [];
+  public configItemType = [];
+  public configType = 'TEXT';
+  public boolValue = true; // default value of select type
 
   @Output() notify: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(
     private configService: ConfigurationService,
     private alertService: AlertService
-  ) {}
+  ) { }
 
   ngOnInit() {
     this.configItemType = ['boolean', 'integer', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password', 'JSON'];
@@ -34,11 +36,11 @@ export class AddConfigItemComponent implements OnInit {
     };
   }
 
-  public setConfigName(desc, key,  selectedRootCategory) {
+  public setConfigName(desc, key, selectedRootCategory) {
     this.categoryData = {
       categoryDescription: desc,
       categoryKey: key,
-      rootCategory:  selectedRootCategory
+      rootCategory: selectedRootCategory
     };
   }
 
@@ -59,10 +61,11 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public addConfigItem(form: NgForm) {
+    console.log('form', form);
     const configItem = form.controls['configName'].value;
     const configItemData = {
       'type': form.controls['type'].value,
-      'default': form.controls['defaultValue'].value,
+      'default': form.controls['defaultValue'].value.toString(),
       'description': form.controls['description'].value
     };
     this.configService
@@ -88,5 +91,31 @@ export class AddConfigItemComponent implements OnInit {
           }
         }
       );
+  }
+
+  public modelChanged(type) {
+
+    if (type != null) {
+      switch (type.toUpperCase()) {
+        case 'IPV4':
+        case 'IPV6':
+        case 'STRING':
+        case 'PASSWORD':
+          this.configType = 'TEXT';
+          break;
+        case 'INTEGER':
+          this.configType = 'NUMBER';
+          break;
+        case 'BOOLEAN':
+          this.configType = 'BOOLEAN';
+          break;
+        case 'JSON':
+        case 'X509 CERTIFICATE':
+          this.configType = 'LONG_TEXT';
+          break;
+        default:
+          break;
+      }
+    }
   }
 }

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -62,12 +62,11 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public addConfigItem(form: NgForm) {
-    console.log(form.value);
     if (form.controls['type'].value === 'JSON') {
       this.isValidJson = ConfigTypeValidation.isValidJsonString(form.controls['defaultValue'].value.trim());
-    }
-    if (!this.isValidJson) {
-      return;
+      if (!this.isValidJson) {
+        return;
+      }
     }
     const configItem = form.controls['configName'].value;
     const configItemData = {
@@ -101,7 +100,7 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public modelChanged(type) {
-    if (type != null) {
+    if (type !== null) {
       this.configFieldType = ConfigTypeValidation.getValueType(type);
     }
   }

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -73,7 +73,7 @@ export class AddConfigItemComponent implements OnInit {
     }
     const configItem = form.controls['configName'].value;
     const configItemData = {
-      'type': form.controls['type'].value.trim().toLowerCase(),
+      'type': form.controls['type'].value,
       'default': form.controls['defaultValue'].value.toString(),
       'description': form.controls['description'].value.trim()
     };
@@ -88,15 +88,6 @@ export class AddConfigItemComponent implements OnInit {
           this.notify.emit(this.categoryData);
           this.toggleModal(false, form);
           this.alertService.success(data['message']);
-          // if (form != null) {
-          //   this.configFieldType = 'TEXT';
-          //   this.resetAddConfigItemForm(form);
-          //   if (form.controls['type'].value.trim().toLowerCase() === 'boolean') {
-          //     form.controls['defaultValue'].setValue(true);
-          //   } else {
-          //     form.controls['defaultValue'].setValue('');
-          //   }
-          // }
         },
         error => {
           if (error.status === 0) {

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -49,6 +49,8 @@ export class AddConfigItemComponent implements OnInit {
     if (form != null) {
       this.isValidJson = true;
       this.resetAddConfigItemForm(form);
+      this.configFieldType = 'TEXT';
+      this.boolValue = true;
     }
     const modal = <HTMLDivElement>document.getElementById('add-config-item');
     if (isOpen) {
@@ -63,7 +65,7 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public addConfigItem(form: NgForm) {
-    if (form.controls['type'].value === 'JSON') {
+    if (form.controls['type'].value.toUpperCase() === 'JSON') {
       this.isValidJson = ConfigTypeValidation.isValidJsonString(form.controls['defaultValue'].value.trim());
       if (!this.isValidJson) {
         return;
@@ -71,9 +73,9 @@ export class AddConfigItemComponent implements OnInit {
     }
     const configItem = form.controls['configName'].value;
     const configItemData = {
-      'type': form.controls['type'].value,
+      'type': form.controls['type'].value.trim().toLowerCase(),
       'default': form.controls['defaultValue'].value.toString(),
-      'description': form.controls['description'].value
+      'description': form.controls['description'].value.trim()
     };
     this.configService
       .addNewConfigItem(
@@ -84,11 +86,17 @@ export class AddConfigItemComponent implements OnInit {
       .subscribe(
         (data) => {
           this.notify.emit(this.categoryData);
-          this.toggleModal(false, null);
+          this.toggleModal(false, form);
           this.alertService.success(data['message']);
-          if (form != null) {
-            this.resetAddConfigItemForm(form);
-          }
+          // if (form != null) {
+          //   this.configFieldType = 'TEXT';
+          //   this.resetAddConfigItemForm(form);
+          //   if (form.controls['type'].value.trim().toLowerCase() === 'boolean') {
+          //     form.controls['defaultValue'].setValue(true);
+          //   } else {
+          //     form.controls['defaultValue'].setValue('');
+          //   }
+          // }
         },
         error => {
           if (error.status === 0) {

--- a/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/add-config-item/add-config-item.component.ts
@@ -1,3 +1,5 @@
+import ConfigTypeValidation, { CONFIG_ITEM_TYPES } from '../configuration-type-validation';
+
 import { Component, EventEmitter, OnInit, Output } from '@angular/core';
 import { NgForm } from '@angular/forms';
 
@@ -11,10 +13,10 @@ import { AlertService, ConfigurationService } from '../../../../services';
 export class AddConfigItemComponent implements OnInit {
   public catName = '';
   public categoryData: any;
-  public configItemType = [];
-  public configType = 'TEXT';
+  public configItemTypes = CONFIG_ITEM_TYPES;
+  public configFieldType = 'TEXT';
   public boolValue = true; // default value of select type
-
+  public isValidJson = true;
   @Output() notify: EventEmitter<any> = new EventEmitter<any>();
 
   constructor(
@@ -23,7 +25,6 @@ export class AddConfigItemComponent implements OnInit {
   ) { }
 
   ngOnInit() {
-    this.configItemType = ['boolean', 'integer', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password', 'JSON'];
     this.categoryData = {
       categoryDescription: '',
       categoryKey: '',
@@ -61,7 +62,13 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public addConfigItem(form: NgForm) {
-    console.log('form', form);
+    console.log(form.value);
+    if (form.controls['type'].value === 'JSON') {
+      this.isValidJson = ConfigTypeValidation.isValidJsonString(form.controls['defaultValue'].value.trim());
+    }
+    if (!this.isValidJson) {
+      return;
+    }
     const configItem = form.controls['configName'].value;
     const configItemData = {
       'type': form.controls['type'].value,
@@ -94,28 +101,8 @@ export class AddConfigItemComponent implements OnInit {
   }
 
   public modelChanged(type) {
-
     if (type != null) {
-      switch (type.toUpperCase()) {
-        case 'IPV4':
-        case 'IPV6':
-        case 'STRING':
-        case 'PASSWORD':
-          this.configType = 'TEXT';
-          break;
-        case 'INTEGER':
-          this.configType = 'NUMBER';
-          break;
-        case 'BOOLEAN':
-          this.configType = 'BOOLEAN';
-          break;
-        case 'JSON':
-        case 'X509 CERTIFICATE':
-          this.configType = 'LONG_TEXT';
-          break;
-        default:
-          break;
-      }
+      this.configFieldType = ConfigTypeValidation.getValueType(type);
     }
   }
 }

--- a/src/app/components/core/configuration-manager/configuration-type-validation.ts
+++ b/src/app/components/core/configuration-manager/configuration-type-validation.ts
@@ -2,7 +2,7 @@ export const CONFIG_ITEM_TYPES = ['boolean', 'integer', 'string', 'IPv4', 'IPv6'
 
 export default class ConfigTypeValidation {
   public static getValueType(configType) {
-    let valueType;
+    let valueType: string;
     switch (configType.toUpperCase()) {
       case 'IPV4':
       case 'IPV6':

--- a/src/app/components/core/configuration-manager/configuration-type-validation.ts
+++ b/src/app/components/core/configuration-manager/configuration-type-validation.ts
@@ -1,0 +1,37 @@
+export const CONFIG_ITEM_TYPES = ['boolean', 'integer', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password', 'JSON'];
+
+export default class ConfigTypeValidation {
+  public static getValueType(configType) {
+    let valueType;
+    switch (configType.toUpperCase()) {
+      case 'IPV4':
+      case 'IPV6':
+      case 'STRING':
+      case 'PASSWORD':
+        valueType = 'TEXT';
+        break;
+      case 'INTEGER':
+        valueType = 'NUMBER';
+        break;
+      case 'BOOLEAN':
+        valueType = 'BOOLEAN';
+        break;
+      case 'JSON':
+      case 'X509 CERTIFICATE':
+        valueType = 'LONG_TEXT';
+        break;
+      default:
+        break;
+    }
+    return valueType;
+  }
+
+  public static isValidJsonString(str) {
+    try {
+      JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/app/components/core/configuration-manager/configuration-type-validation.ts
+++ b/src/app/components/core/configuration-manager/configuration-type-validation.ts
@@ -1,4 +1,12 @@
-export const CONFIG_ITEM_TYPES = ['Boolean', 'Integer', 'String', 'IPv4', 'IPv6', 'X509 certificate', 'Password', 'JSON'];
+export const CONFIG_ITEM_TYPES = [
+  {'key': 'boolean', 'value': 'Boolean'},
+  {'key': 'string', 'value': 'String'},
+  {'key': 'integer', 'value': 'Integer'},
+  {'key': 'password', 'value': 'Password'},
+  {'key': 'IPv4', 'value': 'IPv4'},
+  {'key': 'IPv6', 'value': 'IPv6'},
+  {'key': 'X509 certificate', 'value': 'X509 certificate'},
+  {'key': 'JSON', 'value': 'JSON'}];
 
 export default class ConfigTypeValidation {
   public static getValueType(configType) {

--- a/src/app/components/core/configuration-manager/configuration-type-validation.ts
+++ b/src/app/components/core/configuration-manager/configuration-type-validation.ts
@@ -1,4 +1,4 @@
-export const CONFIG_ITEM_TYPES = ['boolean', 'integer', 'string', 'IPv4', 'IPv6', 'X509 certificate', 'password', 'JSON'];
+export const CONFIG_ITEM_TYPES = ['Boolean', 'Integer', 'String', 'IPv4', 'IPv6', 'X509 certificate', 'Password', 'JSON'];
 
 export default class ConfigTypeValidation {
   public static getValueType(configType) {

--- a/src/app/components/core/configuration-manager/configuration.module.ts
+++ b/src/app/components/core/configuration-manager/configuration.module.ts
@@ -10,6 +10,7 @@ import { AuthCheckGuard } from '../../../guards';
 import { ConfigurationService } from '../../../services';
 import { SharedModule } from '../../../shared.module';
 import { AddConfigItemComponent } from './add-config-item/add-config-item.component';
+import { DirectivesModule } from '../../../directives/directives.module';
 
 const routes: Routes = [
   {
@@ -30,6 +31,7 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     NgProgressModule,
     SharedModule,
+    DirectivesModule,
     TreeModule
   ],
   providers: [ConfigurationService],

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -34,7 +34,7 @@
                     type="text" [textContent]='configItem?.value?.value != undefined ? configItem?.value?.value : ""'>
                     {{configItem?.value?.value}}
                     </textarea>
-                  <div *ngIf="!isValidJson && (configItem.value.type | uppercase) == 'JSON'" class="help is-danger level-left">Invalid JSON</div>
+                  <div *ngIf="!isValidJson && (selectedCategoryId === (categoryConfigurationData.key.trim() + '-' + configItem.key.trim() | lowercase)) && (configItem.value.type | uppercase) == 'JSON'" class="help is-danger level-left">Invalid JSON</div>
                 </div>
               </div>
             </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -35,6 +35,7 @@
                     {{configItem?.value?.value}}
                     </textarea>
                   <div *ngIf="!isValidJson && (selectedCategoryId === (categoryConfigurationData.key.trim() + '-' + configItem.key.trim() | lowercase)) && (configItem.value.type | uppercase) == 'JSON'" class="help is-danger level-left">Invalid JSON</div>
+                  <div *ngIf="isEmptyValue && (selectedCategoryId === (categoryConfigurationData.key.trim() + '-' + configItem.key.trim() | lowercase))" class="help is-danger level-left">Field can't left blank</div>
                 </div>
               </div>
             </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -14,6 +14,7 @@ export class ViewConfigItemComponent implements OnInit {
   public selectedValue: string;
   public isValidJson = true;
   public selectedCategoryId: string;
+  public isEmptyValue = false;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -26,7 +27,7 @@ export class ViewConfigItemComponent implements OnInit {
     if (itemKey.includes('select')) {
       itemKey = itemKey.replace('select-', '');
     }
-
+    this.isEmptyValue = false;
     let htmlElement: any;
     htmlElement = <HTMLInputElement>document.getElementById(itemKey);
     if (htmlElement == null) {
@@ -47,6 +48,7 @@ export class ViewConfigItemComponent implements OnInit {
 
   public saveConfigValue(categoryName, configItem, type) {
     const catItemId = categoryName.toLowerCase() + '-' + configItem.toLowerCase();
+    this.selectedCategoryId = catItemId;
     let htmlElement: any;
     htmlElement = <HTMLInputElement>document.getElementById(catItemId);
 
@@ -54,15 +56,18 @@ export class ViewConfigItemComponent implements OnInit {
     if (htmlElement == null) {
       htmlElement = <HTMLSelectElement>document.getElementById('select-' + catItemId);
       value = htmlElement.options[htmlElement.selectedIndex].value;
+      this.isEmptyValue = false;
     } else {
       value = htmlElement.value.trim();
+      if (value.length === 0) {
+        this.isEmptyValue = true;
+        return;
+      }
     }
 
     if (type.toUpperCase() === 'JSON') {
       this.isValidJson = ConfigTypeValidation.isValidJsonString(value);
-
       if (!this.isValidJson) {
-        this.selectedCategoryId = catItemId;
         return;
       }
     }
@@ -110,5 +115,9 @@ export class ViewConfigItemComponent implements OnInit {
     }
     const cancelButton = <HTMLButtonElement>document.getElementById('btn-cancel-' + configItemKey.toLowerCase());
     cancelButton.classList.remove('hidden');
+    if (value.trim().length === 0) {
+      this.isEmptyValue = false;
+      return;
+    }
   }
 }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -13,6 +13,7 @@ export class ViewConfigItemComponent implements OnInit {
   @Input() categoryConfigurationData: any;
   public selectedValue: string;
   public isValidJson = true;
+  public selectedCategoryId: string;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -59,7 +60,9 @@ export class ViewConfigItemComponent implements OnInit {
 
     if (type.toUpperCase() === 'JSON') {
       this.isValidJson = ConfigTypeValidation.isValidJsonString(value);
+
       if (!this.isValidJson) {
+        this.selectedCategoryId = catItemId;
         return;
       }
     }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -115,7 +115,8 @@ export class ViewConfigItemComponent implements OnInit {
     }
     const cancelButton = <HTMLButtonElement>document.getElementById('btn-cancel-' + configItemKey.toLowerCase());
     cancelButton.classList.remove('hidden');
-    if (value.trim().length === 0) {
+    console.log('value', value);
+    if (value.trim().length !== 0) {
       this.isEmptyValue = false;
       return;
     }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { ConfigurationService, AlertService } from '../../../../services';
+
 import { NgProgress } from '../../../../../../node_modules/ngx-progressbar';
+import { AlertService, ConfigurationService } from '../../../../services';
+import ConfigTypeValidation from '../configuration-type-validation';
 
 @Component({
   selector: 'app-view-config-item',
@@ -37,7 +39,7 @@ export class ViewConfigItemComponent implements OnInit {
     cancelButton.classList.add('hidden');
 
     if (configType.toUpperCase() === 'JSON') {
-      this.isValidJson = this.isValidJsonString(configValue);
+      this.isValidJson = ConfigTypeValidation.isValidJsonString(configValue);
       return;
     }
   }
@@ -56,7 +58,7 @@ export class ViewConfigItemComponent implements OnInit {
     }
 
     if (type.toUpperCase() === 'JSON') {
-      this.isValidJson = this.isValidJsonString(value);
+      this.isValidJson = ConfigTypeValidation.isValidJsonString(value);
       if (!this.isValidJson) {
         return;
       }
@@ -95,37 +97,7 @@ export class ViewConfigItemComponent implements OnInit {
   }
 
   public getConfigAttributeType(key) {
-    let type = '';
-    switch (key.trim().toUpperCase()) {
-      case 'STRING':
-      case 'IPV4':
-      case 'IPV6':
-      case 'PASSWORD':
-        type = 'TEXT';
-        break;
-      case 'INTEGER':
-        type = 'NUMBER';
-        break;
-      case 'BOOLEAN':
-        type = 'BOOLEAN';
-        break;
-      case 'JSON':
-      case 'X509 CERTIFICATE':
-        type = 'LONG_TEXT';
-        break;
-      default:
-        break;
-    }
-    return type;
-  }
-
-  public isValidJsonString(str) {
-    try {
-      JSON.parse(str);
-    } catch (e) {
-      return false;
-    }
-    return true;
+    return ConfigTypeValidation.getValueType(key);
   }
 
   public onTextChange(configItemKey, value) {

--- a/src/app/components/core/scheduler/scheduler.module.ts
+++ b/src/app/components/core/scheduler/scheduler.module.ts
@@ -4,7 +4,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { NgProgressModule } from 'ngx-progressbar';
 
-import { InputMaskDirective } from '../../../directives/input-mask.directive';
 import { PipesModule } from '../../../pipes/pipes.module';
 import { AlertDialogModule } from '../../common/alert-dialog/alert-dialog.module';
 import { CreateScheduleComponent } from './create-schedule/create-schedule.component';
@@ -13,6 +12,7 @@ import { ListTasksComponent } from './list-tasks/list-tasks.component';
 import { ScheduledProcessComponent } from './scheduled-process/scheduled-process.component';
 import { UpdateScheduleComponent } from './update-schedule/update-schedule.component';
 import { AuthCheckGuard } from '../../../guards';
+import { DirectivesModule } from '../../../directives/directives.module';
 
 const routes: Routes = [
   {
@@ -29,7 +29,6 @@ const routes: Routes = [
     CreateScheduleComponent,
     UpdateScheduleComponent,
     ListSchedulesComponent,
-    InputMaskDirective
   ],
   imports: [
     ReactiveFormsModule,
@@ -38,9 +37,10 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     NgProgressModule,
     PipesModule,
-    AlertDialogModule
+    AlertDialogModule,
+    DirectivesModule
   ],
   providers: [],
-  exports: [InputMaskDirective]
+  exports: []
 })
 export class SchedulerModule { }

--- a/src/app/components/core/services-health/service-health.module.ts
+++ b/src/app/components/core/services-health/service-health.module.ts
@@ -10,6 +10,7 @@ import { SharedModule } from '../../../shared.module';
 import { AlertDialogModule } from '../../common/alert-dialog/alert-dialog.module';
 import { AddServiceWizardComponent } from './add-service-wizard/add-service-wizard.component';
 import { ServicesHealthComponent } from './services-health.component';
+import { DirectivesModule } from '../../../directives/directives.module';
 
 const routes: Routes = [
   {
@@ -36,7 +37,8 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     NgProgressModule,
     AlertDialogModule,
-    SharedModule
+    SharedModule,
+    DirectivesModule
   ],
   providers: [ServicesHealthService],
 })

--- a/src/app/components/core/user-management/user.management.module.ts
+++ b/src/app/components/core/user-management/user.management.module.ts
@@ -4,13 +4,13 @@ import { FormsModule } from '@angular/forms';
 import { RouterModule, Routes } from '@angular/router';
 import { NgProgressModule } from 'ngx-progressbar';
 import { UserManagementComponent } from '.';
-import { EqualValidatorDirective } from '../../../directives/equal-validator.directive';
 import { AlertDialogModule } from '../../common/alert-dialog/alert-dialog.module';
 import { CreateUserComponent } from './create-user/create-user.component';
 import { UpdateUserComponent } from './update-user/update-user.component';
 import { UserProfileComponent } from './user-profile/user-profile.component';
 import { AdminGuard, AuthGuard } from '../../../guards';
 import { ResetPasswordComponent } from './reset-password/reset-password.component';
+import { DirectivesModule } from '../../../directives/directives.module';
 
 const routes: Routes = [
   {
@@ -35,15 +35,15 @@ const routes: Routes = [
     UpdateUserComponent,
     CreateUserComponent,
     UserProfileComponent,
-    ResetPasswordComponent,
-    EqualValidatorDirective
+    ResetPasswordComponent
   ],
   imports: [
     FormsModule,
     CommonModule,
     RouterModule.forChild(routes),
     NgProgressModule,
-    AlertDialogModule
+    AlertDialogModule,
+    DirectivesModule
   ],
   providers: [AuthGuard, AdminGuard],
   exports: []

--- a/src/app/directives/directives.module.ts
+++ b/src/app/directives/directives.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { NumberOnlyDirective } from './number-only.directive';
+import { EqualValidatorDirective } from './equal-validator.directive';
+import { InputMaskDirective } from './input-mask.directive';
+import { InputTrimDirective } from './input-trim.directive';
+
+
+@NgModule({
+  imports: [],
+  declarations: [NumberOnlyDirective, EqualValidatorDirective, InputMaskDirective, InputTrimDirective],
+  exports: [NumberOnlyDirective, EqualValidatorDirective, InputMaskDirective, InputTrimDirective]
+})
+export class DirectivesModule { }

--- a/src/app/shared.module.ts
+++ b/src/app/shared.module.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ViewConfigItemComponent } from './components/core/configuration-manager/view-config-item/view-config-item.component';
 import { PipesModule } from './pipes/pipes.module';
+import { DirectivesModule } from './directives/directives.module';
 
 @NgModule({
-  imports: [CommonModule, PipesModule, FormsModule],
+  imports: [CommonModule, PipesModule, FormsModule, DirectivesModule],
   declarations: [ViewConfigItemComponent],
   exports: [ViewConfigItemComponent]
 })


### PR DESCRIPTION
#### Verification of data type value in configuration manager
FOR  CONFIG TYPE = `STRING` `IPV4` `IPV6`  `PASSWORD` => Input type is `TEXT`

FOR CONFIG TYPE `INTEGER` => Input type is  `NUMBER`;

FOR CONFIG TYPE `BOOLEAN` => Input type is  `SELECT BOX`;

FOR CONFIG TYPE  `JSON`  `X509 CERTIFICATE` => Input type is  'TEXT AREA';
