### PR TITLE
Assets and readings page changes [FOGL-1638]

### DIFF
--- a/src/app/components/common/chart/chart.component.ts
+++ b/src/app/components/common/chart/chart.component.ts
@@ -34,6 +34,7 @@ export class ChartComponent implements OnInit, OnChanges, OnDestroy {
     //   });
     //   this.chart.update();
     // }
+    this.chart.update(0);
   }
 
   ngOnDestroy() {

--- a/src/app/components/core/asset-readings/asset-summary/asset-summary.component.html
+++ b/src/app/components/core/asset-readings/asset-summary/asset-summary.component.html
@@ -3,7 +3,7 @@
   <div class="modal-card">
     <header class="modal-card-head">
       <p [hidden]='!isValidData' class="modal-card-title is-size-5">{{assetCode}}
-        <button (click)="refreshData(assetCode, timeValue.inputValue, selectedType.value)" 
+        <button (click)="refreshData(assetCode, timeValue.inputValue, selectedType.value)"
         class="button is-small">
           <i class="fa fa-refresh" aria-hidden="true"></i>
         </button>

--- a/src/app/components/core/asset-readings/assets/assets.component.html
+++ b/src/app/components/core/asset-readings/assets/assets.component.html
@@ -1,7 +1,4 @@
 <div class="container is-fluid">
-  <ng-progress [positionUsing]="'marginLeft'" [minimum]="0.15" [maximum]="1" [speed]="200" [showSpinner]="true" [direction]="'leftToRightIncreased'"
-    [color]="'#1B95E0'" [trickleSpeed]="300" [thick]="true" [ease]="'linear'">
-  </ng-progress>
   <div class="card">
     <div class="card-content">
       <div class="content">

--- a/src/app/components/core/asset-readings/assets/assets.component.html
+++ b/src/app/components/core/asset-readings/assets/assets.component.html
@@ -3,15 +3,6 @@
     [color]="'#1B95E0'" [trickleSpeed]="300" [thick]="true" [ease]="'linear'">
   </ng-progress>
   <div class="card">
-    <header>
-      <div id="card-title" class="card-content">
-        <h5 class="title is-5"> Assets
-          <button (click)="getAsset()" class="button is-small">
-            <i class="fa fa-refresh" aria-hidden="true"></i>
-          </button>
-        </h5>
-      </div>
-    </header>
     <div class="card-content">
       <div class="content">
         <table class="table is-striped is-narrow scroll is-responsive">
@@ -20,7 +11,6 @@
               <th>Asset</th>
               <th>Readings</th>
               <th></th>
-              <th></th>
             </tr>
           </thead>
           <tbody>
@@ -28,11 +18,6 @@
               <td>{{asset.assetCode}}</td>
               <td>
                 <small>{{asset.count}}</small>
-              </td>
-              <td>
-                <a (click)="showAssetSummary(asset.assetCode)" class="is-pulled-right">
-                  <i class="fa fa-list-alt" aria-hidden="true"></i>
-                </a>
               </td>
               <td>
                 <a (click)="showAssetChart(asset.assetCode)" class="is-pulled-right">
@@ -45,86 +30,5 @@
       </div>
     </div>
   </div>
-  <div class="card">
-    <header>
-      <div id="card-title" class="card-content">
-        <h5 class="title is-5">Asset Readings
-          <button (click)="getAsset(); setAssetCode(selectedAsset)" class="button is-small">
-            <i class="fa fa-refresh" aria-hidden="true"></i>
-          </button>
-        </h5>
-      </div>
-    </header>
-    <div class="card-content">
-      <div class="columns">
-        <div class="column is-4">
-          <div class="select is-fullwidth is-small">
-            <select (ngModelChange)="setAssetCode($event)" [ngModel]="selectedAsset || 'Select'">
-              <option disabled [ngValue]="">Select</option>
-              <option *ngFor="let asset of assets" [ngValue]='asset'>{{asset.assetCode}} ({{asset.count}})</option>
-            </select>
-          </div>
-        </div>
-        <div class="column">
-          <div class="columns is-mobile">
-            <div class="column">
-              <app-number-input-debounce placeholder="limit" (value)="setLimit($event)" [val]="limit"></app-number-input-debounce>
-              <p *ngIf='isInvalidLimit' class='help is-danger'>Limit must be in range 1 - {{MAX_RANGE}}</p>
-            </div>
-            <div class="column">
-              <app-number-input-debounce placeholder="offset" (value)="setOffset($event)" [val]="offset"></app-number-input-debounce>
-              <p *ngIf='isInvalidOffset' class='help is-danger'>Offset must be in range 1 - {{MAX_RANGE}}</p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <table class="table is-striped is-narrow scroll is-responsive">
-        <thead>
-          <tr>
-            <th>Asset</th>
-            <th>Readings&nbsp;&nbsp;
-              <span class="tooltip is-tooltip-right" data-tooltip="DD-MM-YYYY HH:mm:ss">
-                <i class="fa fa-info-circle"></i>
-              </span>
-            </th>
-            <th *ngIf="isSummary">
-              <button (click)="showAssetSummary(selectedAsset.assetCode)" class="button is-pulled-right is-small">
-                <i class="fa fa-list-alt" aria-hidden="true"></i> &nbsp; Summary
-              </button>
-            </th>
-            <th *ngIf="isChart">
-              <button (click)="showAssetChart(selectedAsset.assetCode)" class="button is-pulled-right is-small">
-                <i class="fa fa-line-chart" aria-hidden="true"></i> &nbsp; Trends
-              </button>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr *ngFor="let asset of assetsReadingsData">
-            <td>
-              <small>{{asset.assetCode}}</small>
-            </td>
-            <td>
-              <tr *ngFor="let d of asset.data">
-                <td>
-                  {{d.reading | json}}
-                </td>
-                <td>
-                  <span class="tag is-rounded">{{d.timestamp | dateparser: 'DD-MM-YYYY HH:mm:ss'}}</span>
-                </td>
-                <hr class="dropdown-divider">
-              </tr>
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <app-asset-summary></app-asset-summary>
-    <app-readings-graph></app-readings-graph>
-    <div *ngIf='totalPagesCount > 1' class="pagination-section">
-      <app-pagination [count]='recordCount' [page]="page" [perPage]='limit' [totalPage]='totalPagesCount' (goPrev)="onPrev()" (goNext)="onNext()"
-        (goFirst)="onFirst()" (goLast)="onLast()" (goPage)="goToPage($event)">
-      </app-pagination>
-    </div>
-  </div>
+  <app-readings-graph></app-readings-graph>
 </div>

--- a/src/app/components/core/asset-readings/assets/assets.component.ts
+++ b/src/app/components/core/asset-readings/assets/assets.component.ts
@@ -1,196 +1,56 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
-import { AssetsService, AlertService } from '../../../../services/index';
+import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
+import { AssetsService, AlertService, PingService } from '../../../../services/index';
 import { AssetSummaryComponent } from './../asset-summary/asset-summary.component';
 import { ReadingsGraphComponent } from './../readings-graph/readings-graph.component';
 import { NgProgress } from 'ngx-progressbar';
 import { MAX_INT_SIZE } from '../../../../utils';
+import { POLLING_INTERVAL } from '../../../../utils';
+import { AnonymousSubscription } from 'rxjs/Subscription';
+import { Observable } from 'rxjs/Rx';
 
 @Component({
   selector: 'app-assets',
   templateUrl: './assets.component.html',
   styleUrls: ['./assets.component.css']
 })
-export class AssetsComponent implements OnInit {
+export class AssetsComponent implements OnInit, OnDestroy {
 
   selectedAsset: any; // Selected asset object (assetCode, count)
-  DEFAULT_LIMIT = 20;
   MAX_RANGE = MAX_INT_SIZE;
-  limit = this.DEFAULT_LIMIT;
-  offset = 0;
-
-  page = 1;           // Default page is 1 in pagination
-  recordCount = 0;    // Total no. of records during pagination
-  tempOffset = 0;     // Temporary offset during pagination
-  totalPagesCount = 0;
   assets = [];
   assetsReadingsData = [];
-
   public assetData: Object;
   public isChart = false;
-  public isSummary = false;
+  public refreshInterval = POLLING_INTERVAL;
+  private timerSubscription: AnonymousSubscription;
+  private postsSubscription: AnonymousSubscription;
 
-  public isInvalidLimit = false;
-  public isInvalidOffset = false;
-
-  @ViewChild(AssetSummaryComponent) assetSummaryComponent: AssetSummaryComponent;
   @ViewChild(ReadingsGraphComponent) readingsGraphComponent: ReadingsGraphComponent;
 
-  constructor(private assetService: AssetsService, private alertService: AlertService, public ngProgress: NgProgress) { }
+  constructor(private assetService: AssetsService,
+    private alertService: AlertService,
+    public ngProgress: NgProgress,
+    private ping: PingService) { }
 
   ngOnInit() {
     this.getAsset();
-  }
-
-  /**
-   *  Go to the page on which user clicked in pagination
-   */
-  goToPage(n: number): void {
-    this.page = n;
-    this.setLimitOffset();
-  }
-
-  /**
-   *  Go to the next page
-   */
-  onNext(): void {
-    this.page++;
-    this.setLimitOffset();
-  }
-
-  /**
-   *  Go to the previous page
-   */
-  onPrev(): void {
-    this.page--;
-    this.setLimitOffset();
-  }
-
-  /**
-   *  Go to the first page
-   */
-  onFirst(): void {
-    this.page = 1;
-    this.setLimitOffset();
-  }
-
-  /**
-   *  Go to the last page
-   */
-  onLast(): void {
-    const p = Math.ceil(this.recordCount / this.limit) || 0;
-    this.page = p;
-    this.setLimitOffset();
-  }
-
-  /**
-   *  Calculate number of pages for pagination based on total records;
-   */
-  public totalPages() {
-    this.totalPagesCount = Math.ceil(this.recordCount / this.limit) || 0;
-  }
-
-  /**
-   *  Set limit and offset (it is internally called by goToPage(), onNext(), onPrev(), onFirst(), onLast()  methods)
-   */
-  setLimitOffset() {
-    if (this.limit === 0) {
-      this.limit = this.DEFAULT_LIMIT;
-    }
-    if (this.offset > 0) {
-      this.tempOffset = ((this.page - 1) * this.limit) + this.offset;
-    } else {
-      this.tempOffset = (this.page - 1) * this.limit;
-    }
-    console.log('limit: ', this.limit);
-    console.log('offset: ', this.offset);
-    console.log('temp offset: ', this.tempOffset);
-    this.getAsset();
-  }
-
-  public setAssetCode(assetData) {
-    if (assetData === undefined) {
-      return;
-    }
-    this.selectedAsset = assetData;
-    this.limit = this.DEFAULT_LIMIT;
-    this.offset = 0;
-    this.tempOffset = 0;
-    this.recordCount = 0;
-    if (this.page !== 1) {
-      this.page = 1;
-    }
-    this.isChart = true;
-    this.isSummary = true;
-    this.getAsset();
-  }
-
-  /**
-   *  Set limit
-   */
-  public setLimit(limit) {
-    if (this.selectedAsset === undefined) {
-      return;
-    }
-    this.isInvalidLimit = false;
-    if (+limit > this.MAX_RANGE) {
-      this.isInvalidLimit = true; // limit range validation
-      return;
-    }
-    if (this.page !== 1) {
-      this.page = 1;
-      this.tempOffset = this.offset;
-    }
-    if (limit === '' || limit == 0 || limit === null || limit === undefined) {
-      limit = this.DEFAULT_LIMIT;
-    }
-    this.limit = limit;
-    console.log('Limit: ', this.limit);
-    this.getAsset();
-  }
-
-  /**
-   *  Set offset
-   */
-  public setOffset(offset: number) {
-    if (this.selectedAsset === undefined) {
-      return;
-    }
-    this.isInvalidOffset = false;
-    if (offset > this.MAX_RANGE) {
-      this.isInvalidOffset = true; // offset range validation
-      return;
-    }
-    if (this.page !== 1) {
-      this.page = 1;
-    }
-    if (offset === null || offset === undefined) {
-      offset = 0;
-    }
-    this.offset = offset;
-    this.tempOffset = offset;
-    console.log('Offset: ', this.offset);
-    this.getAsset();
+    this.ping.pingIntervalChanged.subscribe((timeInterval: number) => {
+      this.refreshInterval = timeInterval;
+    });
   }
 
   public getAsset(): void {
     this.assets = [];
-    /** request started */
-    this.ngProgress.start();
     this.assetService.getAsset().
       subscribe(
         (data: any[]) => {
-          /** request completed */
-          this.ngProgress.done();
           this.assets = data;
           if (this.selectedAsset) {
             this.selectedAsset = this.assets.find(a => a.assetCode === this.selectedAsset.assetCode);
-            this.recordCount = this.selectedAsset['count'] - this.offset;
-            this.getAssetReading();
           }
+          this.refreshData();
         },
         error => {
-          /** request completed */
-          this.ngProgress.done();
           if (error.status === 0) {
             console.log('service down ', error);
           } else {
@@ -199,56 +59,56 @@ export class AssetsComponent implements OnInit {
         });
   }
 
-  /**
-   *  Get data of Asset Readings
-   */
-  public getAssetReading(): void {
-    if (this.offset === 0) {
-      this.recordCount = this.selectedAsset['count'];
-    }
-    this.assetsReadingsData = [];
-    /** request started */
-    this.ngProgress.start();
-    this.assetService.getAssetReadings(encodeURIComponent(this.selectedAsset['assetCode']), this.limit, this.tempOffset).
-      subscribe(
-        data => {
-          /** request completed */
-          this.ngProgress.done();
-          this.assetsReadingsData = [{
-            assetCode: this.selectedAsset['assetCode'],
-            count: this.recordCount,
-            data: data
-          }];
-          this.totalPages();
-          console.log('This is the asset reading data ', this.assetsReadingsData);
-        },
-        error => {
-          /** request completed */
-          this.ngProgress.done();
-          if (error.status === 0) {
-            console.log('service down ', error);
-          } else {
-            this.alertService.error(error.statusText);
-          }
-        });
-  }
-
-  /**
- * Open asset summary modal dialog
- */
-  public showAssetSummary(assetCode) {
-    const dataObj = {
-      assetCode: assetCode,
-    };
-    this.assetSummaryComponent.getReadingSummary(dataObj);
-    this.assetSummaryComponent.toggleModal(true);
-  }
+  // /**
+  //  *  Get data of Asset Readings
+  //  */
+  // public getAssetReading(): void {
+  //   this.assetsReadingsData = [];
+  //   /** request started */
+  //   this.ngProgress.start();
+  //   this.assetService.getAssetReadings(encodeURIComponent(this.selectedAsset['assetCode'])).
+  //     subscribe(
+  //       data => {
+  //         /** request completed */
+  //         this.ngProgress.done();
+  //         this.assetsReadingsData = [{
+  //           assetCode: this.selectedAsset['assetCode'],
+  //           data: data
+  //         }];
+  //         console.log('This is the asset reading data ', this.assetsReadingsData);
+  //       },
+  //       error => {
+  //         /** request completed */
+  //         this.ngProgress.done();
+  //         if (error.status === 0) {
+  //           console.log('service down ', error);
+  //         } else {
+  //           this.alertService.error(error.statusText);
+  //         }
+  //       });
+  // }
 
   /**
   * Open asset chart modal dialog
   */
   public showAssetChart(assetCode) {
-    this.readingsGraphComponent.plotReadingsGraph(assetCode, 0, 0);
+    this.readingsGraphComponent.plotReadingsGraph(assetCode, 0);
     this.readingsGraphComponent.toggleModal(true);
   }
+
+  public ngOnDestroy(): void {
+    if (this.postsSubscription) {
+      this.postsSubscription.unsubscribe();
+    }
+    if (this.timerSubscription) {
+      this.timerSubscription.unsubscribe();
+    }
+  }
+
+  private refreshData(): void {
+    this.timerSubscription = null;
+    this.timerSubscription = Observable.timer(this.refreshInterval)
+      .subscribe(() => this.getAsset());
+  }
+
 }

--- a/src/app/components/core/asset-readings/assets/assets.component.ts
+++ b/src/app/components/core/asset-readings/assets/assets.component.ts
@@ -1,10 +1,7 @@
 import { Component, OnInit, OnDestroy, ViewChild } from '@angular/core';
 import { AssetsService, AlertService, PingService } from '../../../../services/index';
-import { AssetSummaryComponent } from './../asset-summary/asset-summary.component';
 import { ReadingsGraphComponent } from './../readings-graph/readings-graph.component';
-import { NgProgress } from 'ngx-progressbar';
-import { MAX_INT_SIZE } from '../../../../utils';
-import { POLLING_INTERVAL } from '../../../../utils';
+import { MAX_INT_SIZE, POLLING_INTERVAL } from '../../../../utils';
 import { AnonymousSubscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Rx';
 
@@ -18,18 +15,15 @@ export class AssetsComponent implements OnInit, OnDestroy {
   selectedAsset: any; // Selected asset object (assetCode, count)
   MAX_RANGE = MAX_INT_SIZE;
   assets = [];
-  assetsReadingsData = [];
   public assetData: Object;
   public isChart = false;
   public refreshInterval = POLLING_INTERVAL;
   private timerSubscription: AnonymousSubscription;
-  private postsSubscription: AnonymousSubscription;
 
   @ViewChild(ReadingsGraphComponent) readingsGraphComponent: ReadingsGraphComponent;
 
   constructor(private assetService: AssetsService,
     private alertService: AlertService,
-    public ngProgress: NgProgress,
     private ping: PingService) { }
 
   ngOnInit() {
@@ -40,7 +34,6 @@ export class AssetsComponent implements OnInit, OnDestroy {
   }
 
   public getAsset(): void {
-    this.assets = [];
     this.assetService.getAsset().
       subscribe(
         (data: any[]) => {
@@ -59,35 +52,6 @@ export class AssetsComponent implements OnInit, OnDestroy {
         });
   }
 
-  // /**
-  //  *  Get data of Asset Readings
-  //  */
-  // public getAssetReading(): void {
-  //   this.assetsReadingsData = [];
-  //   /** request started */
-  //   this.ngProgress.start();
-  //   this.assetService.getAssetReadings(encodeURIComponent(this.selectedAsset['assetCode'])).
-  //     subscribe(
-  //       data => {
-  //         /** request completed */
-  //         this.ngProgress.done();
-  //         this.assetsReadingsData = [{
-  //           assetCode: this.selectedAsset['assetCode'],
-  //           data: data
-  //         }];
-  //         console.log('This is the asset reading data ', this.assetsReadingsData);
-  //       },
-  //       error => {
-  //         /** request completed */
-  //         this.ngProgress.done();
-  //         if (error.status === 0) {
-  //           console.log('service down ', error);
-  //         } else {
-  //           this.alertService.error(error.statusText);
-  //         }
-  //       });
-  // }
-
   /**
   * Open asset chart modal dialog
   */
@@ -97,16 +61,13 @@ export class AssetsComponent implements OnInit, OnDestroy {
   }
 
   public ngOnDestroy(): void {
-    if (this.postsSubscription) {
-      this.postsSubscription.unsubscribe();
-    }
     if (this.timerSubscription) {
       this.timerSubscription.unsubscribe();
+      this.timerSubscription = null;
     }
   }
 
   private refreshData(): void {
-    this.timerSubscription = null;
     this.timerSubscription = Observable.timer(this.refreshInterval)
       .subscribe(() => this.getAsset());
   }

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -23,16 +23,16 @@
               <b>{{readings.key}} &nbsp;</b>
             </span>
             <span class="tag is-light"> Avg </span>
-            <span class="tag is-info">{{reading.average}}</span> &nbsp;
+            <span class="tag is-info">{{roundTo(reading.average, 5)}}</span> &nbsp;
             <span class="tag is-light"> Min </span>
-            <span class="tag is-info">{{reading.min}}</span> &nbsp;
+            <span class="tag is-info">{{roundTo(reading.min, 5)}}</span> &nbsp;
             <span class="tag is-light"> Max </span>
-            <span class="tag is-info">{{reading.max}}</span> &nbsp;
+            <span class="tag is-info">{{roundTo(reading.max, 5)}}</span> &nbsp;
           </div>
         </div>
       </div>
       <p *ngIf='!showGraph'> Not Available </p>
-      <app-chart *ngIf='showGraph' [type]="assetChart" [data]="assetReadingValues" [options]=""></app-chart>
+      <app-chart *ngIf='showGraph' [type]="assetChartType" [data]="assetReadingValues" [options]=""></app-chart>
     </section>
   </div>
 </div>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -3,24 +3,17 @@
   <div class="modal-card">
     <header class="modal-card-head">
       <p class="modal-card-title is-size-5">{{assetCode}}
-        <button [hidden]='!showGraph' (click)="plotReadingsGraph(assetCode, limit.inputValue, offset.inputValue)" class="button is-small">
-          <i class="fa fa-refresh" aria-hidden="true"></i>
-        </button>
       </p>
       <div class="close">
-        <button class="delete" aria-label="close" (click)="toggleModal(false); clearField(limit, offset)"></button>
+        <button class="delete" aria-label="close" (click)="toggleModal(false); clearField(limit)"></button>
       </div>
     </header>
     <section class="modal-card-body">
       <div [hidden]='!showGraph' class="columns is-mobile">
         <div class="column">
-          <app-number-input-debounce placeholder="limit" #limit (value)="plotReadingsGraph(assetCode, limit.inputValue, offset.inputValue)"
+          <app-number-input-debounce placeholder="number of readings" #limit (value)="plotReadingsGraph(assetCode, limit.inputValue)"
             max="{{MAX_RANGE}}"></app-number-input-debounce>
-          <p *ngIf='isInvalidLimit' class='help is-danger'>Limit must be in range 1 - {{MAX_RANGE}}</p>
-        </div>
-        <div class="column">
-          <app-number-input-debounce placeholder="offset" #offset (value)="plotReadingsGraph(assetCode, limit.inputValue, offset.inputValue)"></app-number-input-debounce>
-          <p *ngIf='isInvalidOffset' class='help is-danger'>Offset must be in range 1 - {{MAX_RANGE}}</p>
+          <p *ngIf='isInvalidLimit' class='help is-danger'>Number of readings must be in range 1 - {{MAX_RANGE}}</p>
         </div>
       </div>
       <div [hidden]='!showGraph' class="field is-grouped is-grouped-multiline" *ngFor="let readings of assetReadingSummary">

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -1,78 +1,86 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
-
-import { MomentDatePipe } from '../../../../pipes/moment-date';
-import { AssetsService, PingService } from '../../../../services';
-import ReadingsValidator from '../assets/readings-validator';
-import { AssetSummaryService } from './../asset-summary/asset-summary-service';
-import { MAX_INT_SIZE } from '../../../../utils';
-import { NgProgress } from 'ngx-progressbar';
-import { POLLING_INTERVAL } from '../../../../utils';
+import { Component } from '@angular/core';
 import { AnonymousSubscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Rx';
+
+import { MomentDatePipe } from '../../../../pipes/moment-date';
+
+import { AssetsService, PingService } from '../../../../services';
+import { AssetSummaryService } from './../asset-summary/asset-summary-service';
+
+import ReadingsValidator from '../assets/readings-validator';
+import { MAX_INT_SIZE, POLLING_INTERVAL } from '../../../../utils';
+
 
 @Component({
   selector: 'app-readings-graph',
   templateUrl: './readings-graph.component.html',
   styleUrls: ['./readings-graph.component.css']
 })
-export class ReadingsGraphComponent implements OnInit, OnDestroy {
-  public assetChart: string;
+export class ReadingsGraphComponent {
+  public assetCode: string;
+  public assetChartType: string;
   public assetReadingValues: any;
-  public assetCode;
   public showGraph = true;
   public assetReadingSummary = [];
   public isInvalidLimit = false;
   public MAX_RANGE = MAX_INT_SIZE;
   public DEFAULT_LIMIT = 100;
-  public refreshInterval = POLLING_INTERVAL;
-  private timerSubscription: AnonymousSubscription;
-  private postsSubscription: AnonymousSubscription;
+  public graphRefreshInterval = POLLING_INTERVAL;
+  private graphTimerSubscription: AnonymousSubscription;
   public limit: number;
 
   constructor(private assetService: AssetsService,
     private assetSummaryService: AssetSummaryService,
-    public ngProgress: NgProgress,
     private ping: PingService) {
-    this.assetChart = 'line';
+    this.assetChartType = 'line';
     this.assetReadingValues = [];
   }
 
-  ngOnInit() {
-    this.ping.pingIntervalChanged.subscribe((timeInterval: number) => {
-      this.refreshInterval = timeInterval;
-    });
+  public roundTo(num, to) {
+    const _to = Math.pow(10, to);
+    return Math.round(num * _to) / _to;
   }
 
   public toggleModal(shouldOpen: Boolean) {
     const chart_modal = <HTMLDivElement>document.getElementById('chart_modal');
     if (shouldOpen) {
+      this.ping.pingIntervalChanged.subscribe((timeInterval: number) => {
+        this.graphRefreshInterval = timeInterval;
+      });
       chart_modal.classList.add('is-active');
       return;
     }
+    if (this.graphTimerSubscription) {
+      this.graphTimerSubscription.unsubscribe();
+      this.graphTimerSubscription = null;
+    }
     chart_modal.classList.remove('is-active');
-    this.assetCode = '';
   }
 
   public plotReadingsGraph(assetCode, limit: any) {
+    if (this.assetCode === '') {
+      return false;
+    }
+    if (this.graphTimerSubscription) {
+      this.graphTimerSubscription.unsubscribe();
+      this.graphTimerSubscription = null;
+    }
+
     this.isInvalidLimit = false;
     if (limit === undefined || limit === null || limit === '' || limit === 0) {
       limit = this.DEFAULT_LIMIT;
-      this.limit = limit;
-    }
-
-    if (!Number.isInteger(+limit) || +limit < 0 || +limit > this.MAX_RANGE) { // max limit of int in c++
-      this.limit = limit;
+    } else if (!Number.isInteger(+limit) || +limit < 0 || +limit > this.MAX_RANGE) { // max limit of int in c++
       this.isInvalidLimit = true;
       return;
     }
 
+    this.limit = limit;
     this.assetCode = assetCode;
-    this.ngProgress.start();
+
     this.assetService.getAssetReadings(encodeURIComponent(assetCode), +limit).
       subscribe(
         (data: any[]) => {
           this.showGraph = true;
-          this.ngProgress.done();
           if (data.length === 0) {
             this.getAssetTimeReading(data);
             return;
@@ -87,21 +95,19 @@ export class ReadingsGraphComponent implements OnInit, OnDestroy {
             this.assetSummaryService.assetReadingSummary.subscribe(
               value => {
                 this.assetReadingSummary = value;
-                console.log('readings data to show trends.', this.assetReadingSummary);
               });
             this.getAssetTimeReading(data);
           } else {
             this.showGraph = false;
           }
-          this.refreshData();
+          this.refreshGraphData();
         },
         error => {
-          this.ngProgress.done();
           console.log('error in response', error);
         });
   }
 
-  getAssetTimeReading(assetChartRecord) {
+  public getAssetTimeReading(assetChartRecord) {
     let assetTimeLabels = [];
     let assetReading = [];
     const first_dataset = [];
@@ -157,7 +163,7 @@ export class ReadingsGraphComponent implements OnInit, OnDestroy {
     this.statsAssetReadingsGraph(assetTimeLabels, assetReading);
   }
 
-  statsAssetReadingsGraph(labels, assetReading): void {
+  private statsAssetReadingsGraph(labels, assetReading): void {
     let ds = [];
     if (assetReading.length === 3) {
       const d1 = assetReading[0].data;
@@ -232,33 +238,23 @@ export class ReadingsGraphComponent implements OnInit, OnDestroy {
         borderColor: '#82E0AA',
       }];
     }
-    this.assetChart = 'line';
+    this.assetChartType = 'line';
     this.setAssetReadingValues(labels, ds);
   }
 
-  setAssetReadingValues(labels, ds) {
+  private setAssetReadingValues(labels, ds) {
     this.assetReadingValues = {
       labels: labels,
       datasets: ds
     };
   }
 
-  clearField(limitField) {
+  public clearField(limitField) {
     limitField.inputValue = '';
   }
 
-  public ngOnDestroy(): void {
-    if (this.postsSubscription) {
-      this.postsSubscription.unsubscribe();
-    }
-    if (this.timerSubscription) {
-      this.timerSubscription.unsubscribe();
-    }
-  }
-
-  private refreshData(): void {
-    this.timerSubscription = null;
-    this.timerSubscription = Observable.timer(this.refreshInterval)
+  private refreshGraphData(): void {
+    this.graphTimerSubscription = Observable.timer(this.graphRefreshInterval)
       .subscribe(() => this.plotReadingsGraph(this.assetCode, this.limit));
   }
 }

--- a/src/app/components/layout/navbar/navbar.component.ts
+++ b/src/app/components/layout/navbar/navbar.component.ts
@@ -119,7 +119,6 @@ export class NavbarComponent implements OnInit, AfterViewInit, OnDestroy {
       }
       this.status.changeMessage(true);
       this.pingData = data;
-      console.log('Data', data);
       this.uptime = Utils.secondsToDhms(data['uptime']).roundOffTime;
       this.pingInfo = { isAlive: true, isAuth: false, hostName: this.pingData['hostName'] };
       if (data['authenticationOptional'] === true) {
@@ -223,7 +222,6 @@ export class NavbarComponent implements OnInit, AfterViewInit, OnDestroy {
           /** request completed */
           this.ngProgress.done();
           this.pingData = [];
-          console.log('this.pingData', this.pingData);
           this.alertService.success(data['message']);
         },
         (error) => {

--- a/src/app/services/assets.service.ts
+++ b/src/app/services/assets.service.ts
@@ -25,20 +25,13 @@ export class AssetsService {
   *  /foglamp/asset/{assetCode}
   * @param assetCode
   * @param limit
-  * @param offset
   *  Return a set of asset readings for the given asset code
   */
-  public getAssetReadings(assetCode, limit: Number = 0, offset: Number = 0) {
+  public getAssetReadings(assetCode, limit: Number = 0) {
     let params = new HttpParams();
-    if (limit && offset) {
+    if (limit) {
       params = params.set('limit', limit.toString());
-      params = params.set('skip', offset.toString());
-    } else if (limit) {
-      params = params.set('limit', limit.toString());
-    } else if (offset) {  // offset works withOUT limit in postgres!
-      params = params.set('skip', offset.toString());
     }
-
     return this.http.get(this.GET_ASSET + '/' + assetCode, { params: params }).pipe(
       map(response => response),
       catchError((error: Response) => observableThrowError(error)));


### PR DESCRIPTION
- [x] Remove “Asset Readings” section (at bottom of page).
- [x] Remove grid icon and functionality. (second icon from right)
- [x] Remove refresh icon and functionality. 
- [x] Remove milliseconds from graphs
- [x] Graphs: remove “offset” box. Change text “limit” to “number of readings”
- [x] Auto-refresh page same as configured ping time.