### PR TITLE
FOGL-1834: south *assetNamePrefix* should allow empty strings

### DIFF
--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -20,7 +20,7 @@
                   <div class="field">
                     <input *ngIf="getConfigAttributeType(configItem.value.type) === 'TEXT'" name="{{configItem.value.key}}" class="input is-fullwidth is-small"
                       type="text" [(ngModel)]="configItem.value.value" [value]='configItem?.value?.value != undefined ? configItem?.value?.value : ""'
-                      required [attr.maxLength]="configItem?.value?.length" />
+                      [required]="configItem.value.key !== 'assetNamePrefix'" [attr.maxLength]="configItem?.value?.length" />
 
                     <input *ngIf="getConfigAttributeType(configItem.value.type) === 'NUMBER'" name="{{configItem.value.key}}" type="number" [value]='configItem?.value?.value != undefined ? configItem?.value?.value : ""'
                       class="input is-fullwidth is-small" [minValue]="configItem?.value?.minimum" [maxValue]="configItem?.value?.maximum"


### PR DESCRIPTION
Removed empty restriction for string field having **assetNamePrefix** key