### PR TITLE
css fixed for Save button on Config and Asset/Readings Page

### DIFF
--- a/src/app/components/core/asset-readings/assets/assets.component.html
+++ b/src/app/components/core/asset-readings/assets/assets.component.html
@@ -24,7 +24,7 @@
               <tbody>
                 <tr *ngFor="let asset of assets">
                   <td>{{asset.assetCode}}</td>
-                  <td class="is-pulled-right">{{asset.count | number}}</td>
+                  <td><span class="is-pulled-right">{{asset.count | number}}</span></td>
                   <td>
                     <a (click)="showAssetChart(asset.assetCode)" class="is-pulled-right">
                       <i class="fa fa-line-chart" aria-hidden="true"></i>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -62,7 +62,7 @@
             <label class="label"></label>
           </div>
           <div class="field-body">
-            <div class="column">
+            <div style="padding-top: 1rem;">
               <button *ngIf="useProxy == 'true'" id="vci-proxy" type="submit"  class="hidden button is-small is-link is-pulled-right">Save</button>
               <button *ngIf="useProxy != 'true'" id="vci" type="submit"  class="button is-small is-link is-pulled-left">Save</button>
             </div>


### PR DESCRIPTION
1. On Config Page, Save button is not aligned with form input boxes.

2. asset readings row; separator line are broken

<img width="258" alt="screen shot 2018-09-14 at 12 04 24 am" src="https://user-images.githubusercontent.com/1974003/45508186-d4146180-b7b1-11e8-8856-962db3753adb.png">
<img width="208" alt="screen shot 2018-09-14 at 12 04 36 am" src="https://user-images.githubusercontent.com/1974003/45508190-d5458e80-b7b1-11e8-9896-c76b362b835a.png">
