### PR TITLE
FOGL-1875: GUI update for displayName in configuration

### DIFF
--- a/src/app/components/core/configuration-manager/configuration-manager.component.html
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.html
@@ -11,7 +11,8 @@
         <div class="panel-heading">
           <div class="select is-rounded is-fullwidth is-small">
             <select (change)="getChildren($event.target.value)">
-              <option *ngFor="let rootCategory of rootCategories" [selected]='rootCategory.key === selectedRootCategory' [value]='rootCategory.key'>{{ rootCategory.description }}</option>
+              <option *ngFor="let rootCategory of rootCategories" [selected]='rootCategory.key === selectedRootCategory' [value]='rootCategory.key'> {{ hasProperty(rootCategory, 'displayName') === true ?
+                  rootCategory.displayName:rootCategory.description}}</option>
             </select>
           </div>
         </div>

--- a/src/app/components/core/configuration-manager/configuration-manager.component.html
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.html
@@ -2,7 +2,7 @@
   <ng-progress [positionUsing]="'marginLeft'" [minimum]="0.15" [maximum]="1" [speed]="200" [showSpinner]="true" [direction]="'leftToRightIncreased'"
     [color]="'#1B95E0'" [trickleSpeed]="300" [thick]="true" [ease]="'linear'">
   </ng-progress>
-  
+
   <!-- cards to be rendered as config.categories.count-->
 
   <div class="columns is-multiline">

--- a/src/app/components/core/configuration-manager/configuration-manager.component.ts
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.ts
@@ -40,7 +40,18 @@ export class ConfigurationManagerComponent implements OnInit {
       subscribe(
         (data) => {
           data['categories'].forEach(element => {
-            this.rootCategories.push({ key: element.key, description: element.description });
+            if (element.hasOwnProperty('displayName')) {
+              this.rootCategories.push({
+                key: element.key,
+                displayName: element.displayName,
+                description: element.description
+              });
+            } else {
+              this.rootCategories.push({
+                key: element.key,
+                description: element.description
+              });
+            }
             this.rootCategories = this.rootCategories.filter(el => el.key.toUpperCase() !== 'SOUTH');
             this.rootCategories = this.rootCategories.filter(el => el.key.toUpperCase() !== 'NORTH');
           });
@@ -205,5 +216,14 @@ export class ConfigurationManagerComponent implements OnInit {
             this.alertService.error(error.statusText);
           }
         });
+  }
+
+  /**
+   * Check if object has a specific key
+   * @param o Object
+   * @param name key name
+   */
+  public hasProperty(o, name) {
+    return o.hasOwnProperty(name);
   }
 }

--- a/src/app/components/core/configuration-manager/configuration-manager.component.ts
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.ts
@@ -80,7 +80,21 @@ export class ConfigurationManagerComponent implements OnInit {
           }
           this.isChild = true;
           data['categories'].forEach(element => {
-            this.nodes.push({ id: element.key, name: element.description, hasChildren: true, children: [] });
+            if (element.hasOwnProperty('displayName')) {
+              this.nodes.push({
+                id: element.key,
+                name: element.displayName,
+                description: element.description,
+                hasChildren: true, children: []
+              });
+            } else {
+              this.nodes.push({
+                id: element.key,
+                name: element.description,
+                description: element.description,
+                hasChildren: true, children: []
+              });
+            }
           });
 
           this.tree.treeModel.update();
@@ -106,7 +120,23 @@ export class ConfigurationManagerComponent implements OnInit {
         subscribe(
           (data) => {
             data['categories'].forEach(element => {
-              event.node.data.children.push({ id: element.key, name: element.description, hasChildren: true, children: [] });
+              if (element.hasOwnProperty('displayName')) {
+                event.node.data.children.push({
+                  id: element.key,
+                  name: element.displayName,
+                  description: element.description,
+                  hasChildren: true,
+                  children: []
+                });
+              } else {
+                event.node.data.children.push({
+                  id: element.key,
+                  name: element.description,
+                  description: element.description,
+                  hasChildren: true,
+                  children: []
+                });
+              }
               this.tree.treeModel.update();
             });
           }, error => {
@@ -120,7 +150,7 @@ export class ConfigurationManagerComponent implements OnInit {
   }
 
   public onNodeActive(event) {
-    this.getCategory(event.node.data.id, event.node.data.name);
+    this.getCategory(event.node.data.id, event.node.data.description);
   }
 
   public resetAllFilters() {
@@ -128,18 +158,18 @@ export class ConfigurationManagerComponent implements OnInit {
     this.getRootCategories(true);
   }
 
-  private getCategory(category_name: string, category_desc: string): void {
+  private getCategory(categoryKey: string, categoryDesc: string): void {
     /** request started */
     this.ngProgress.start();
     const categoryValues = [];
-    this.configService.getCategory(category_name).
+    this.configService.getCategory(categoryKey).
       subscribe(
         (data: any) => {
           /** request completed */
           this.ngProgress.done();
           if (!isEmpty(data)) {
             categoryValues.push(data);
-            this.categoryData = [{ key: category_name, value: categoryValues, description: category_desc }];
+            this.categoryData = [{ key: categoryKey, value: categoryValues, description: categoryDesc }];
           }
         },
         error => {
@@ -153,18 +183,18 @@ export class ConfigurationManagerComponent implements OnInit {
         });
   }
 
-  public refreshCategory(category_name: string, category_desc: string): void {
+  public refreshCategory(categoryKey: string, categoryDesc: string): void {
     /** request started */
     this.ngProgress.start();
     const categoryValues = [];
-    this.configService.getCategory(category_name).
+    this.configService.getCategory(categoryKey).
       subscribe(
         (data) => {
           /** request completed */
           this.ngProgress.done();
           categoryValues.push(data);
-          const index = findIndex(this.categoryData, ['key', category_name]);
-          this.categoryData[index] = { key: category_name, value: categoryValues, description: category_desc };
+          const index = findIndex(this.categoryData, ['key', categoryKey]);
+          this.categoryData[index] = { key: categoryKey, value: categoryValues, description: categoryDesc };
         },
         error => {
           /** request completed */
@@ -175,15 +205,5 @@ export class ConfigurationManagerComponent implements OnInit {
             this.alertService.error(error.statusText);
           }
         });
-  }
-
-  /**
-  * @param notify
-  * To reload categories after adding a new config item for a category
-  */
-  onNotify(categoryData) {
-    this.selectedRootCategory = categoryData.rootCategory;
-    this.getRootCategories();
-    this.refreshCategory(categoryData.categoryKey, categoryData.categoryDescription);
   }
 }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -7,7 +7,8 @@
             <div class="field is-horizontal">
               <div class="field-label has-text-left">
                 <label class="label tooltip is-tooltip-right is-tooltip-multiline" [attr.data-tooltip]="configItem.value.description">
-                  {{configItem.value.key}}
+                  {{ hasProperty(configItem.value, 'displayName') === true ?
+                  configItem.value.displayName:configItem.value.key}}
                 </label>
               </div>
               <div class="field-body">
@@ -29,8 +30,8 @@
                       [(ngModel)]="configItem.value.value" appNumberOnly required />
 
                     <input *ngIf="getConfigAttributeType(configItem.value.type) === 'FLOAT'" name="{{configItem.value.key}}"
-                      type="number" [value]='configItem?.value?.value != undefined ? configItem?.value?.value : ""' step="any" 
-                      class="input is-fullwidth is-small" [minValue]="configItem?.value?.minimum" [maxValue]="configItem?.value?.maximum"
+                      type="number" [value]='configItem?.value?.value != undefined ? configItem?.value?.value : ""'
+                      step="any" class="input is-fullwidth is-small" [minValue]="configItem?.value?.minimum" [maxValue]="configItem?.value?.maximum"
                       [(ngModel)]="configItem.value.value" appNumberOnly required />
 
                     <textarea rows="3" *ngIf="getConfigAttributeType(configItem.value.type) === 'LONG_TEXT'" class="textarea is-fullwidth is-small"

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -7,8 +7,7 @@
             <div class="field is-horizontal">
               <div class="field-label has-text-left">
                 <label class="label tooltip is-tooltip-right is-tooltip-multiline" [attr.data-tooltip]="configItem.value.description">
-                  {{ hasProperty(configItem.value, 'displayName') === true ?
-                  configItem.value.displayName:configItem.value.key}}
+                  {{setDisplayName(configItem.value)}}
                 </label>
               </div>
               <div class="field-body">

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -35,6 +35,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
           if (currentConfigValue[0].hasOwnProperty(key)) {
             const element = currentConfigValue[0][key];
             element.key = key;
+            // element.displayName = key.toUpperCase();
             configAttributes.push(element);
           }
         }
@@ -116,5 +117,14 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
 
   public getConfigAttributeType(key) {
     return ConfigTypeValidation.getValueType(key);
+  }
+
+  /**
+   * Check if object has a specific key
+   * @param o Object
+   * @param name key name
+   */
+  public hasProperty(o, name) {
+    return o.hasOwnProperty(name);
   }
 }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -37,7 +37,6 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
           if (currentConfigValue[0].hasOwnProperty(key)) {
             const element = currentConfigValue[0][key];
             element.key = key;
-            // element.displayName = key.toUpperCase();
             configAttributes.push(element);
           }
         }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -154,4 +154,15 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public hasProperty(o, name) {
     return o.hasOwnProperty(name);
   }
+
+  /**
+   * display config item name on gui
+   * @param configItem config item object
+   */
+  public setDisplayName(configItem) {
+    if (this.hasProperty(configItem, 'displayName')) {
+      return configItem.displayName.trim().length > 0 ? configItem.displayName : configItem.key;
+    }
+    return configItem.key;
+  }
 }


### PR DESCRIPTION
Added support the use of displayName for categories and for configuration items if it is available in the JSON data.

Depends on FOGL-1874  branch (https://github.com/foglamp/FogLAMP/tree/FOGL-1874)