### PR TITLE
FOGL-2129: Change textarea to readonly/preview mode in case of config type=script

### DIFF
--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -38,9 +38,9 @@
                       [attr.maxLength]="configItem?.value?.length" [jsonValue]="setConfigValue(configItem.value)">{{configItem?.value?.value != undefined ? configItem?.value?.value : configItem?.value?.default}}</textarea>
 
                     <div *ngIf="getConfigAttributeType(configItem.value.type) === 'SCRIPT'">
-                      <textarea rows="3" class="textarea is-fullwidth is-small"
-                        name="{{configItem.value.key}}" [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
-                        [attr.maxLength]="configItem?.value?.length" disabled>
+                      <textarea rows="3" class="textarea is-fullwidth is-small" name="{{configItem.value.key}}"
+                        [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
+                        disabled>
                         {{configItem?.value?.value != undefined ? configItem?.value?.value : configItem?.value?.default}}
                       </textarea>
                       <p class="help">{{configItem?.value?.file | slice:configItem?.value?.file?.lastIndexOf('/')+1}}</p>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -37,9 +37,14 @@
                       name="{{configItem.value.key}}" [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
                       [attr.maxLength]="configItem?.value?.length" [jsonValue]="setConfigValue(configItem.value)">{{configItem?.value?.value != undefined ? configItem?.value?.value : configItem?.value?.default}}</textarea>
 
-                    <textarea rows="3" *ngIf="getConfigAttributeType(configItem.value.type) === 'SCRIPT'" class="textarea is-fullwidth is-small"
-                      name="{{configItem.value.key}}" [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
-                      [attr.maxLength]="configItem?.value?.length">{{configItem?.value?.value != undefined ? configItem?.value?.value : configItem?.value?.default}}</textarea>
+                    <div *ngIf="getConfigAttributeType(configItem.value.type) === 'SCRIPT'">
+                      <textarea rows="3" class="textarea is-fullwidth is-small"
+                        name="{{configItem.value.key}}" [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
+                        [attr.maxLength]="configItem?.value?.length" disabled>
+                        {{configItem?.value?.value != undefined ? configItem?.value?.value : configItem?.value?.default}}
+                      </textarea>
+                      <p class="help">{{configItem?.value?.file | slice:configItem?.value?.file?.lastIndexOf('/')+1}}</p>
+                    </div>
 
                     <div *ngIf="getConfigAttributeType(configItem.value.type) == 'ENUMERATION'" class="select is-small">
                       <select name='{{configItem.value.key}}' [ngModel]="setConfigValue(configItem.value)">


### PR DESCRIPTION
1. Changed textarea in readonly/preview mode
2. Name of file displayed under textarea
 
<img width="633" alt="screen shot 2018-11-29 at 3 29 14 pm" src="https://user-images.githubusercontent.com/16384273/49214066-d1f29400-f3eb-11e8-971d-85d7e63f4f9f.png">
