### PR TITLE
FOGL-2205: Filter GUI feedback fix

### DIFF
--- a/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.ts
+++ b/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.ts
@@ -105,7 +105,8 @@ export class AddFilterWizardComponent implements OnInit {
         nxtButton.textContent = 'Next';
         previousButton.textContent = 'Previous';
 
-         // To verify if filter with given name already exist
+         // To verify if category (or filter itself) with this name already exists
+         // hence filter can not be created with that name
          const isFilterExist = this.categories.some(item => {
           return formValues['name'].trim() === item.key;
         });

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -28,8 +28,13 @@ label{
 a { color: black; }
 
 .toggle::before{
-  top:.3em !important;
   content:'\25BC' !important;
+  padding: 4px 3px 0 3px !important;
+  text-align: center !important;
+}
+
+.accordions .accordion.is-active .accordion-header .toggle::before{
+  content:'\25B2' !important;
 }
 
 .btnDelete {

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -48,4 +48,17 @@ a { color: black; }
 
 .switch-icon:hover > .fa + .fa {
   display: inherit;
+  opacity: 0.5;
+}
+
+.fa-bars {
+  opacity: 0.5;
+}
+
+.fa-trash.fa-lg {
+  opacity: 0.8;
+}
+
+.add-application{
+  opacity: 0.7;
 }

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -27,10 +27,20 @@ label{
 
 a { color: black; }
 
-.toggle::before {
-  top: 0.2em !important;
+.toggle::before{
+  top:.3em !important;
+  content:'\25BC' !important;
 }
 
 .btnDelete {
   margin: 2px;
+}
+
+.switch-icon > .fa + .fa,
+.switch-icon:hover > .fa {
+  display: none;
+}
+
+.switch-icon:hover > .fa + .fa {
+  display: inherit;
 }

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -10,7 +10,7 @@
     </header>
     <section class="modal-card-body">
       <ng-container *ngIf="!isWizard">
-        <div class="box animated slideInLeft">
+        <div class="box">
           <app-view-config-item #serviceConfigView *ngIf="category" [categoryConfigurationData]="category" [useProxy]="useProxy"></app-view-config-item>
           <div *ngIf="childConfiguration != null" class="field is-horizontal is-pulled-right" style="margin-bottom: 0%;">
             <button class="button is-small is-text" (click)="getAdvanceConfig(childConfiguration)">{{advanceConfigButtonText}}</button>
@@ -49,16 +49,17 @@
                 <article *ngFor="let filter of filterPipeline; let i = index" [dndDraggable]="filter" (dndStart)="onDragStart(i)"
                   class="is-light accordion" [attr.id]="i">
 
-                  <div class="accordion-header" (click)="activeAccordion(i, filter)">
-                    <p>{{filter}}</p>
-                    <button class="is-dark toggle" aria-label="toggle"></button>
+                  <div class="accordion-header">
+                    <span><span class="switch-icon"><i class="fa fa-bars"></i><i class="fa fa-hand-rock-o"></i></span>&nbsp;{{filter}}</span>
+                    <button class="is-dark toggle" aria-label="toggle" (click)="activeAccordion(i, filter)"></button>
                   </div>
                   <div class="accordion-body">
                     <div class="accordion-content" hidden>
                       <app-view-config-item #filterConfigView *ngIf="filterConfiguration" [categoryConfigurationData]="filterConfiguration"
                         [useFilterProxy]="useFilterProxy" [formId]="item"></app-view-config-item>
                       <div class="field is-pulled-right">
-                        <button class="button is-light btnDelete" (click)="deleteFilterReference(filter)"><span class="icon is-medium"><i class="fa fa-trash fa-lg" aria-hidden="true"></i></span></button>
+                        <button class="button is-light btnDelete" (click)="deleteFilterReference(filter)"><span class="icon is-medium"><i
+                              class="fa fa-trash fa-lg" aria-hidden="true"></i></span></button>
                       </div>
                     </div>
                   </div>
@@ -113,5 +114,6 @@
     </section>
   </div>
   <app-alert-dialog (deleteService)='deleteService($event)' [serviceRecord]='serviceRecord'></app-alert-dialog>
-  <app-filter-alert *ngIf="isFilterOrderChanged || isFilterDeleted" (discardChanges)="discardChanges($event)" [filerDialogData]='confirmationDialogData'></app-filter-alert>
+  <app-filter-alert *ngIf="isFilterOrderChanged || isFilterDeleted" (discardChanges)="discardChanges($event)"
+    [filerDialogData]='confirmationDialogData'></app-filter-alert>
 </div>

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -36,7 +36,7 @@
           <hr>
           <div class="columns">
             <div class="column has-text-centered">
-              <span class="label is-size-6"><a (click)="openAddFilterModal(true)">Applications <i class="fa fa-plus-circle"
+              <span class="label is-size-6 add-application"><a (click)="openAddFilterModal(true)">Applications <i class="fa fa-plus-circle"
                     aria-hidden="true"></i></a></span>
             </div>
           </div>


### PR DESCRIPTION
- [x] Fixed Initial open animation of south modal 
- [ ] Adding the RMS filter shows enable option in middle of options. Enable should always be last   [FOGL-2206](https://scaledb.atlassian.net/browse/FOGL-2206)
- [ ] “enable” should instead be “enabled” as it is for the south/north service.  [FOGL-2206](https://scaledb.atlassian.net/browse/FOGL-2206)
- [x] icon to open folded app is currently a “+”. It should be a down arrow. 
- [ ] opening the “delta” filter doesn’t fit in the popup. **(Not able to reproduce)**
- [x] Added  hamburger icon on left of filter in South config to indicate the user can grab that to move it. 
- [x] When cursor hovers over that hamburger, icon change to a grab icon
