### PR TITLE
FOGL-2261: filter gui issues

### DIFF
--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.css
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.css
@@ -29,26 +29,18 @@ a { color: black; }
 
 .toggle::before{
   content:'\25BC' !important;
-  padding: 4px 3px 0 3px !important;
-  text-align: center !important;
+  transform: rotate(180deg);
+  transform-origin: 50% 45%;
 }
 
 .accordions .accordion.is-active .accordion-header .toggle::before{
   content:'\25B2' !important;
+  transform: rotate(180deg);
+  transform-origin: 50% 50%;
 }
 
 .btnDelete {
   margin: 2px;
-}
-
-.switch-icon > .fa + .fa,
-.switch-icon:hover > .fa {
-  display: none;
-}
-
-.switch-icon:hover > .fa + .fa {
-  display: inherit;
-  opacity: 0.5;
 }
 
 .fa-bars {
@@ -71,4 +63,10 @@ a { color: black; }
 
 .filter-header:hover{
   cursor: move;
+}
+
+.accordion-body {
+  border: none !important;
+  border-bottom: 1px solid #dbdbdb !important;
+  border-radius: 2px !important;
 }

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.css
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.css
@@ -68,3 +68,7 @@ a { color: black; }
     display: block !important;
   }
 }
+
+.filter-header:hover{
+  cursor: move;
+}

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -66,17 +66,15 @@
                     aria-hidden="true"></i></a></span>
             </div>
           </div>
-          <hr>
           <div *ngIf="filterPipeline != undefined" class="view-content columns">
             <div class="column">
               <section class="accordions" dndDropzone dndEffectAllowed="copyMove" (dndDrop)="onDrop($event, filterPipeline)">
 
                 <article dndPlaceholderRef class="is-light accordion dndPlaceholder">
                 </article>
-                <article *ngFor="let filter of filterPipeline; let i = index" [dndDraggable]="filter" (dndStart)="onDragStart(i)"
-                  class="is-light accordion" [attr.id]="i">
+                <article *ngFor="let filter of filterPipeline; let i = index" class="is-light accordion" [attr.id]="i">
 
-                  <div class="accordion-header">
+                  <div class="accordion-header" [ngClass]="{'filter-header': filterPipeline?.length > 1}" [dndDraggable]="filter" (dndStart)="onDragStart(i)">
                     <span><span class="switch-icon"><i class="fa fa-bars"></i><i class="fa fa-hand-rock-o"></i></span>&nbsp;{{filter}}</span>
                     <button class="is-dark toggle" aria-label="toggle" (click)="toggleAccordion(i, filter)"></button>
                   </div>
@@ -124,5 +122,5 @@
   </div>
   <app-alert-dialog (deleteTask)='deleteTask($event)' [deleteTaskData]='deleteTaskData'></app-alert-dialog>
   <app-filter-alert *ngIf="isFilterOrderChanged || isFilterDeleted" (discardChanges)="discardChanges($event)"
-  [filerDialogData]='confirmationDialogData'></app-filter-alert>
+    [filerDialogData]='confirmationDialogData'></app-filter-alert>
 </div>

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -75,7 +75,7 @@
                 <article *ngFor="let filter of filterPipeline; let i = index" class="is-light accordion" [attr.id]="i">
 
                   <div class="accordion-header" [ngClass]="{'filter-header': filterPipeline?.length > 1}" [dndDraggable]="filter" (dndStart)="onDragStart(i)">
-                    <span><span class="switch-icon"><i class="fa fa-bars"></i><i class="fa fa-hand-rock-o"></i></span>&nbsp;{{filter}}</span>
+                    <span><i class="fa fa-bars"></i>&nbsp;{{filter}}</span>
                     <button class="is-dark toggle" aria-label="toggle" (click)="toggleAccordion(i, filter)"></button>
                   </div>
                   <div class="accordion-body">

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -29,12 +29,15 @@ a { color: black; }
 
 .toggle::before{
   content:'\25BC' !important;
-  padding: 4px 3px 0 3px !important;
-  text-align: center !important;
+  transform: rotate(180deg);
+  transform-origin: 50% 45%;
 }
+
 
 .accordions .accordion.is-active .accordion-header .toggle::before{
   content:'\25B2' !important;
+  transform: rotate(180deg);
+  transform-origin: 50% 50%;
 }
 
 .filter-header:hover{

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -45,6 +45,12 @@ a { color: black; }
   transform-origin: 50% 50%;
 }
 
+.accordion-body {
+  border: none !important;
+  border-bottom: 1px solid #dbdbdb !important;
+  border-radius: 2px !important;
+}
+
 .filter-header:hover{
   cursor: move;
 }

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.css
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.css
@@ -37,18 +37,12 @@ a { color: black; }
   content:'\25B2' !important;
 }
 
+.filter-header:hover{
+  cursor: move;
+}
+
 .btnDelete {
   margin: 2px;
-}
-
-.switch-icon > .fa + .fa,
-.switch-icon:hover > .fa {
-  display: none;
-}
-
-.switch-icon:hover > .fa + .fa {
-  display: inherit;
-  opacity: 0.5;
 }
 
 .fa-bars {

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -44,13 +44,13 @@
             <div class="column">
               <section class="accordions" dndDropzone dndEffectAllowed="copyMove" (dndDrop)="onDrop($event, filterPipeline)">
 
-                <article dndPlaceholderRef class="is-light accordion dndPlaceholder">
+                <article dndPlaceholderRef class="is-light" [ngClass]="{'accordion dndPlaceholder': filterPipeline?.length > 1}">
                 </article>
                 <article *ngFor="let filter of filterPipeline; let i = index" [dndDraggable]="filter" (dndStart)="onDragStart(i)"
                   class="is-light accordion" [attr.id]="i">
 
-                  <div class="accordion-header">
-                    <span><span class="switch-icon"><i class="fa fa-bars"></i><i class="fa fa-hand-rock-o"></i></span>&nbsp;{{filter}}</span>
+                  <div class="accordion-header" [ngClass]="{'filter-header': filterPipeline?.length > 1}">
+                    <span><span class="switch-icon"><i class="fa fa-bars"></i></span>&nbsp;{{filter}}</span>
                     <button class="is-dark toggle" aria-label="toggle" (click)="activeAccordion(i, filter)"></button>
                   </div>
                   <div class="accordion-body">

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -46,10 +46,8 @@
 
                 <article dndPlaceholderRef class="is-light accordion dndPlaceholder">
                 </article>
-                <article *ngFor="let filter of filterPipeline; let i = index" [dndDraggable]="filter" (dndStart)="onDragStart(i)"
-                  class="is-light accordion" [attr.id]="i">
-
-                  <div class="accordion-header" [ngClass]="{'filter-header': filterPipeline?.length > 1}">
+                <article *ngFor="let filter of filterPipeline; let i = index" class="is-light accordion" [attr.id]="i">
+                  <div class="accordion-header" [dndDraggable]="filter" (dndStart)="onDragStart(i)" [ngClass]="{'filter-header': filterPipeline?.length > 1}">
                     <span><span class="switch-icon"><i class="fa fa-bars"></i></span>&nbsp;{{filter}}</span>
                     <button class="is-dark toggle" aria-label="toggle" (click)="activeAccordion(i, filter)"></button>
                   </div>

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -44,7 +44,7 @@
             <div class="column">
               <section class="accordions" dndDropzone dndEffectAllowed="copyMove" (dndDrop)="onDrop($event, filterPipeline)">
 
-                <article dndPlaceholderRef class="is-light" [ngClass]="{'accordion dndPlaceholder': filterPipeline?.length > 1}">
+                <article dndPlaceholderRef class="is-light accordion dndPlaceholder">
                 </article>
                 <article *ngFor="let filter of filterPipeline; let i = index" [dndDraggable]="filter" (dndStart)="onDragStart(i)"
                   class="is-light accordion" [attr.id]="i">

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.ts
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.ts
@@ -113,22 +113,25 @@ export class SouthServiceModalComponent implements OnInit, OnChanges {
       this.showConfirmationDialog();
       return;
     }
+
     const activeFilterTab = <HTMLElement>document.getElementsByClassName('accordion is-active')[0];
     if (activeFilterTab !== undefined) {
       activeFilterTab.classList.remove('is-active');
     }
 
-    const modalWindow = <HTMLDivElement>document.getElementById('south-service-modal');
-
     if (this.isWizard) {
       this.getCategory();
       this.isWizard = false;
     }
+
+    const modalWindow = <HTMLDivElement>document.getElementById('south-service-modal');
     if (isOpen) {
+      this.notify.emit(false);
       this.svcCheckbox.setValue(this.service['schedule_enabled']);
       modalWindow.classList.add('is-active');
       return;
     }
+    this.notify.emit(false);
     this.isAdvanceConfig = true;
     this.getAdvanceConfig(null);
     modalWindow.classList.remove('is-active');


### PR DESCRIPTION
- [x] when cursor moves over a filter, the cursor should change to a "move cursor" the hamburger in the filter should not change

- [ ] when the filter is moved, it should disappear from the list. So if there are two filters, rms and delta, and the user grabs rms and moves it, the rms filter should disappear from the list, so only delta is displayed, and the user has two options, to drop rms above delta, or below it. (currently, rms and delta both display, and user has three possibilities: drop above rms, between rms & delta, or below delta)

If there is only one filter, re-arranging capability should not be allowed. i.e.
- [x] hovering over a single filter should not change to the move cursor, and 
- [ ] that filter cannot be moved.

Also:
- [x] when a filter is expanded / collapsed, the "open" icon / the "close" should be centered
- [x] Fixed drag issue on filter config area [drag is applicable on header only]