### PR TITLE
FOGL-2269: Selecting item from plugin list adds description but make dialog resize

### DIFF
--- a/src/app/components/core/configuration-manager/configuration-manager.component.html
+++ b/src/app/components/core/configuration-manager/configuration-manager.component.html
@@ -45,7 +45,7 @@
         </header>
         <div class="card-content">
           <div class="content">
-            <app-view-config-item [categoryConfigurationData]="category"></app-view-config-item>
+            <app-view-config-item [categoryConfigurationData]="category" [pageId]="'page'"></app-view-config-item>
           </div>
         </div>
       </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -78,24 +78,24 @@
             </div>
           </div>
         </ng-container>
-        <div class="field is-horizontal">
-          <div class="field-label has-text-left">
-            <label class="label"></label>
-          </div>
-          <div class="field-body">
-            <div style="padding-top: 1rem;">
-              <button *ngIf="useFilterProxy == 'true'" [attr.id]="formId" type="submit" class="hidden button is-small is-link is-pulled-right vci-proxy-filter">Save</button>
-              <button *ngIf="useProxy == 'true'" id="vci-proxy" type="submit"  class="hidden button is-small is-link is-pulled-right">Save</button>
-              <button *ngIf="useProxy != 'true' && useFilterProxy != 'true'" id="vci" type="submit"  class="button is-small is-link is-pulled-left">Save</button>
-            </div>
-          </div>
+      </ng-container>
+      <ng-container *ngIf="!hasEditableConfigItems && pageId == 'wizard'">
+        <div class="has-text-centered">
+          <small class="no-rec">No configurable item found, Please click Next</small>
         </div>
       </ng-container>
-      <ng-container *ngIf="!hasEditableConfigItems">
-          <div class="has-text-centered">
-              <small class="no-rec">No configurable item found.</small>
-            </div>
-      </ng-container>
+      <div class="field is-horizontal">
+        <div class="field-label has-text-left">
+          <label class="label"></label>
+        </div>
+        <div class="field-body">
+          <div style="padding-top: 1rem;">
+            <button *ngIf="useFilterProxy == 'true'" [attr.id]="formId" type="submit" class="hidden button is-small is-link is-pulled-right vci-proxy-filter">Save</button>
+            <button *ngIf="useProxy == 'true'" id="vci-proxy" type="submit"  class="hidden button is-small is-link is-pulled-right">Save</button>
+            <button *ngIf="useProxy != 'true' && useFilterProxy != 'true'" id="vci" type="submit"  class="button is-small is-link is-pulled-left">Save</button>
+          </div>
+        </div>
+      </div>
     </form>
   </div>
 </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -1,7 +1,7 @@
 <div class="view-content columns">
   <div class="column">
     <form name="form" id="ngForm" (ngSubmit)="saveConfiguration(f)" #f="ngForm" novalidate>
-      <ng-container *ngIf="categoryConfiguration != undefined">
+      <ng-container *ngIf="categoryConfiguration != undefined && hasConfiguration">
         <ng-container *ngFor="let configItem of (categoryConfiguration.value | keys)">
           <div class="config-div" *ngIf="configItem.value.readonly != 'true'">
             <div class="field is-horizontal">
@@ -90,6 +90,11 @@
             </div>
           </div>
         </div>
+      </ng-container>
+      <ng-container *ngIf="!hasConfiguration">
+          <div class="has-text-centered">
+              <small class="no-rec">No configurable item found.</small>
+            </div>
       </ng-container>
     </form>
   </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -1,7 +1,7 @@
 <div class="view-content columns">
   <div class="column">
     <form name="form" id="ngForm" (ngSubmit)="saveConfiguration(f)" #f="ngForm" novalidate>
-      <ng-container *ngIf="categoryConfiguration != undefined && hasConfiguration">
+      <ng-container *ngIf="categoryConfiguration != undefined && hasEditableConfigItems">
         <ng-container *ngFor="let configItem of (categoryConfiguration.value | keys)">
           <div class="config-div" *ngIf="configItem.value.readonly != 'true'">
             <div class="field is-horizontal">
@@ -91,7 +91,7 @@
           </div>
         </div>
       </ng-container>
-      <ng-container *ngIf="!hasConfiguration">
+      <ng-container *ngIf="!hasEditableConfigItems">
           <div class="has-text-centered">
               <small class="no-rec">No configurable item found.</small>
             </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -16,6 +16,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   @Input() useProxy: 'false';
   @Input() useFilterProxy: 'false';
   @Input() formId: '';
+  @Input() pageId: 'page';
   @Output() onConfigChanged: EventEmitter<any> = new EventEmitter<any>();
 
   public categoryConfiguration;

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -1,6 +1,6 @@
 import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { NgForm } from '@angular/forms';
-import { differenceWith, sortBy, isEqual, isEmpty, cloneDeep } from 'lodash';
+import { differenceWith, sortBy, isEqual, isEmpty, cloneDeep, has } from 'lodash';
 import { NgProgress } from 'ngx-progressbar';
 
 import { AlertService, ConfigurationService } from '../../../../services';
@@ -23,6 +23,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public isValidForm: boolean;
   public isWizardCall = false;
   public filesToUpload = [];
+  public hasConfiguration = false;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -57,6 +58,15 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
             type: el.type
           };
         });
+        // Verify if all config object have a readonly key
+        for (const el of this.categoryConfiguration.value) {
+          if (!has(el, 'readonly')) {
+            this.hasConfiguration = true;
+            break;
+          } else {
+            this.hasConfiguration = false;
+          }
+        }
       }
     }
   }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -23,7 +23,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public isValidForm: boolean;
   public isWizardCall = false;
   public filesToUpload = [];
-  public hasConfiguration = false;
+  public hasEditableConfigItems = false;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -61,10 +61,10 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
         // Verify if all config object have a readonly key
         for (const el of this.categoryConfiguration.value) {
           if (!has(el, 'readonly')) {
-            this.hasConfiguration = true;
+            this.hasEditableConfigItems = true;
             break;
           } else {
-            this.hasConfiguration = false;
+            this.hasEditableConfigItems = false;
           }
         }
       }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -59,7 +59,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
             type: el.type
           };
         });
-        // Verify if all config object have a readonly key
+        // check if editable config item found, based on readonly property
         for (const el of this.categoryConfiguration.value) {
           if (!has(el, 'readonly')) {
             this.hasEditableConfigItems = true;

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -13,10 +13,10 @@ import ConfigTypeValidation from '../configuration-type-validation';
 })
 export class ViewConfigItemComponent implements OnInit, OnChanges {
   @Input() categoryConfigurationData: any;
-  @Input() useProxy: 'false';
-  @Input() useFilterProxy: 'false';
-  @Input() formId: '';
-  @Input() pageId: 'page';
+  @Input() useProxy: string =  'false';
+  @Input() useFilterProxy: string = 'false';
+  @Input() formId: string = '';
+  @Input() pageId: string = 'page';
   @Output() onConfigChanged: EventEmitter<any> = new EventEmitter<any>();
 
   public categoryConfiguration;
@@ -24,7 +24,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public isValidForm: boolean;
   public isWizardCall = false;
   public filesToUpload = [];
-  public hasEditableConfigItems = false;
+  public hasEditableConfigItems: boolean = true;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,

--- a/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
+++ b/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
@@ -29,7 +29,7 @@
               </select>
             </div>
             &nbsp;
-            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{ selectedPluginDescription }}</small>
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">{{ selectedPluginDescription }}</small>
             <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
             <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>
           </div>

--- a/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
+++ b/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
@@ -22,18 +22,16 @@
             <label class="label">Plugin</label>
           </div>
           <div class="field-body">
-            <div class="field">
-              <div class="control">
-                <div class="select is-multiple">
-                  <select #selectedPlugin multiple name="type" formControlName="plugin" (change)="getDescription(selectedPlugin.value)" required>
-                    <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
-                  </select>
-                </div>
-                <small *ngIf="selectedPluginDescription" class="help level-left">* {{ selectedPluginDescription }}</small>
-                <small *ngIf="!isValidPlugin" class="help is-danger level-left">Please select a valid plugin</small>
-                <small *ngIf="!isSinglePlugin" class="help is-danger level-left">Please select a single plugin</small>
-              </div>
+            <div class="select is-multiple">
+              <select #selectedPlugin multiple name="type" formControlName="plugin" (change)="getDescription(selectedPlugin.value)"
+                required>
+                <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
+              </select>
             </div>
+            &nbsp;
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{ selectedPluginDescription }}</small>
+            <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
+            <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>
           </div>
         </div>
         <div *ngIf="plugins.length > 0" class="field is-horizontal form-group">
@@ -51,8 +49,8 @@
         </div>
       </div>
       <div class="box step-content" id="c-2">
-        <app-view-config-item [hidden]="!configurationData" [categoryConfigurationData]="configurationData"
-        [useProxy]="useProxy" (onConfigChanged)="getChangedConfig($event)"></app-view-config-item>
+        <app-view-config-item [hidden]="!configurationData" [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
+          (onConfigChanged)="getChangedConfig($event)"></app-view-config-item>
       </div>
     </form>
   </div>

--- a/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
+++ b/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.html
@@ -50,7 +50,7 @@
       </div>
       <div class="box step-content" id="c-2">
         <app-view-config-item [hidden]="!configurationData" [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
-          (onConfigChanged)="getChangedConfig($event)"></app-view-config-item>
+          (onConfigChanged)="getChangedConfig($event)" [pageId]="'wizard'"></app-view-config-item>
       </div>
     </form>
   </div>

--- a/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.ts
+++ b/src/app/components/core/filter/add-filter-wizard/add-filter-wizard.component.ts
@@ -168,6 +168,7 @@ export class AddFilterWizardComponent implements OnInit {
 
   getDescription(selectedPlugin) {
     this.isSinglePlugin = true;
+    this.isValidPlugin = true;
     const plugin = (selectedPlugin.slice(3).trim()).replace(/'/g, '');
     this.selectedPluginDescription = this.plugins.find(p => p.name === plugin).description;
   }

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
@@ -88,7 +88,8 @@
       </div>
 
       <div class="box step-content" id="c-2">
-        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy" (onConfigChanged)="getChangedConfig($event)"></app-view-config-item>
+        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
+        (onConfigChanged)="getChangedConfig($event)" [pageId]="wizard"></app-view-config-item>
       </div>
 
       <div class="box step-content" id="c-3">

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
@@ -89,7 +89,7 @@
 
       <div class="box step-content" id="c-2">
         <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
-        (onConfigChanged)="getChangedConfig($event)" [pageId]="wizard"></app-view-config-item>
+        (onConfigChanged)="getChangedConfig($event)" [pageId]="'wizard'"></app-view-config-item>
       </div>
 
       <div class="box step-content" id="c-3">

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
@@ -35,7 +35,7 @@
               </select>
             </div>
             &nbsp;
-            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">{{
               selectedPluginDescription }}</small>
             <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
             <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>
@@ -88,8 +88,8 @@
       </div>
 
       <div class="box step-content" id="c-2">
-        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
-        (onConfigChanged)="getChangedConfig($event)" [pageId]="'wizard'"></app-view-config-item>
+        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy" (onConfigChanged)="getChangedConfig($event)"
+          [pageId]="'wizard'"></app-view-config-item>
       </div>
 
       <div class="box step-content" id="c-3">

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.html
@@ -28,18 +28,17 @@
             <label class="label">North Plugin</label>
           </div>
           <div class="field-body">
-            <div class="field">
-              <div class="control">
-                <div class="select is-multiple">
-                  <select multiple #selectedPlugin name="plugin" formControlName="plugin" (change)="getDescription(selectedPlugin.value)" required>
-                    <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
-                  </select>
-                </div>
-                <small *ngIf="selectedPluginDescription" class="help level-left">* {{ selectedPluginDescription }}</small>
-                <small *ngIf="!isValidPlugin" class="help is-danger level-left">Please select a valid plugin</small>
-                <small *ngIf="!isSinglePlugin" class="help is-danger level-left">Please select a single plugin</small>
-              </div>
+            <div class="select is-multiple">
+              <select multiple #selectedPlugin name="plugin" formControlName="plugin" (change)="getDescription(selectedPlugin.value)"
+                required>
+                <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
+              </select>
             </div>
+            &nbsp;
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{
+              selectedPluginDescription }}</small>
+            <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
+            <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>
           </div>
         </div>
         <div class="field is-horizontal form-group">

--- a/src/app/components/core/north/add-task-wizard/add-task-wizard.component.ts
+++ b/src/app/components/core/north/add-task-wizard/add-task-wizard.component.ts
@@ -329,6 +329,7 @@ export class AddTaskWizardComponent implements OnInit {
 
   getDescription(selectedPlugin) {
     this.isSinglePlugin = true;
+    this.isValidPlugin = true;
     const plugin = (selectedPlugin.slice(3).trim()).replace(/'/g, '');
     this.selectedPluginDescription = this.plugins.find(p => p.name === plugin).description;
   }

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -11,7 +11,8 @@
     <section class="modal-card-body">
       <ng-container *ngIf="!isWizard">
         <div class="box">
-          <app-view-config-item #taskConfigView *ngIf="category" [categoryConfigurationData]="category" [useProxy]="useProxy"></app-view-config-item>
+          <app-view-config-item #taskConfigView *ngIf="category" [categoryConfigurationData]="category"
+          [useProxy]="useProxy" [pageId]="'modal'"></app-view-config-item>
           <form name="task-form" id="taskForm" #fg="ngForm" (ngSubmit)="saveScheduleFields(fg)" novalidate>
             <div class="columns">
               <div class="column">

--- a/src/app/components/core/north/north-task-modal/north-task-modal.component.html
+++ b/src/app/components/core/north/north-task-modal/north-task-modal.component.html
@@ -93,6 +93,7 @@
               </section>
             </div>
           </div>
+          <hr>
           <div class="columns">
             <div class="column">
               <div class="field is-grouped is-pulled-right">

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
@@ -31,18 +31,17 @@
             <label class="label">South Plugin</label>
           </div>
           <div class="field-body">
-            <div class="field">
-              <div class="control">
-                <div class="select is-multiple">
-                  <select multiple name="type" #selectedPlugin formControlName="plugin" (change)="getDescription(selectedPlugin.value)" required>
-                    <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
-                  </select>
-                </div>
-                <small *ngIf="selectedPluginDescription" class="help level-left">* {{ selectedPluginDescription }}</small>
-                <small *ngIf="!isValidPlugin" class="help is-danger level-left">Please select a valid plugin</small>
-                <small *ngIf="!isSinglePlugin" class="help is-danger level-left">Please select a single plugin</small>
-              </div>
+            <div class="select is-multiple">
+              <select multiple name="type" #selectedPlugin formControlName="plugin" (change)="getDescription(selectedPlugin.value)"
+                required>
+                <option *ngFor="let p of plugins" [value]="p.name"> {{ p.name }}</option>
+              </select>
             </div>
+            &nbsp;
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{
+              selectedPluginDescription }}</small>
+            <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
+            <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>
           </div>
         </div>
         <div *ngIf="plugins.length > 0" class="field is-horizontal form-group">

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
@@ -59,7 +59,8 @@
         </div>
       </div>
       <div class="box step-content" id="c-2">
-        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy" (onConfigChanged)="getChangedConfig($event)"></app-view-config-item>
+        <app-view-config-item [categoryConfigurationData]="configurationData" [useProxy]="useProxy"
+        (onConfigChanged)="getChangedConfig($event)" [pageId]="'wizard'"></app-view-config-item>
       </div>
       <div class="box step-content" id="c-3">
         <div class="field is-horizontal">

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.html
@@ -38,7 +38,7 @@
               </select>
             </div>
             &nbsp;
-            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">* {{
+            <small *ngIf="selectedPluginDescription && isValidPlugin && isSinglePlugin" class="help level-left">{{
               selectedPluginDescription }}</small>
             <small *ngIf="!isValidPlugin" class="help is-danger level-left">* Please select a valid plugin</small>
             <small *ngIf="!isSinglePlugin" class="help is-danger level-left">* Please select a single plugin</small>

--- a/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
+++ b/src/app/components/core/south/add-service-wizard/add-service-wizard.component.ts
@@ -91,6 +91,7 @@ export class AddServiceWizardComponent implements OnInit {
 
   getDescription(selectedPlugin) {
     this.isSinglePlugin = true;
+    this.isValidPlugin = true;
     const plugin = (selectedPlugin.slice(3).trim()).replace(/'/g, '');
     this.selectedPluginDescription = this.plugins.find(p => p.name === plugin).description;
   }

--- a/src/app/components/core/south/south-service-modal/south-service-modal.component.html
+++ b/src/app/components/core/south/south-service-modal/south-service-modal.component.html
@@ -11,7 +11,8 @@
     <section class="modal-card-body">
       <ng-container *ngIf="!isWizard">
         <div class="box">
-          <app-view-config-item #serviceConfigView *ngIf="category" [categoryConfigurationData]="category" [useProxy]="useProxy"></app-view-config-item>
+          <app-view-config-item #serviceConfigView *ngIf="category" [categoryConfigurationData]="category"
+          [useProxy]="useProxy" [pageId]="'modal'"></app-view-config-item>
           <div *ngIf="childConfiguration != null" class="field is-horizontal is-pulled-right" style="margin-bottom: 0%;">
             <button class="button is-small is-text" (click)="getAdvanceConfig(childConfiguration)">{{advanceConfigButtonText}}</button>
           </div>

--- a/src/app/components/layout/navbar/navbar.component.css
+++ b/src/app/components/layout/navbar/navbar.component.css
@@ -57,3 +57,7 @@
 .safe-mode {
   padding-left: 24px;
 }
+
+.dropdown-item{
+  width: max-content;
+}

--- a/src/app/components/layout/navbar/navbar.component.html
+++ b/src/app/components/layout/navbar/navbar.component.html
@@ -154,7 +154,7 @@
                           <span class="icon" [ngClass]="applyServiceStatusCustomCss(s.status)">
                             <i class="fa fa-circle"></i>
                           </span>
-                          {{s.name.length <= 18 ? s.name :  s.name.substr(0,19) + '..'}}&nbsp;
+                          {{s.name.length <= 18 ? s.name :  s.name.substr(0,18) + '..'}}&nbsp;
                         </td>
                         <td>
                           <b>{{s.status}}</b>

--- a/src/app/components/layout/navbar/navbar.component.html
+++ b/src/app/components/layout/navbar/navbar.component.html
@@ -154,7 +154,7 @@
                           <span class="icon" [ngClass]="applyServiceStatusCustomCss(s.status)">
                             <i class="fa fa-circle"></i>
                           </span>
-                          {{s.name.substr(0,19)}}..&nbsp;
+                          {{s.name.length <= 18 ? s.name :  s.name.substr(0,19) + '..'}}&nbsp;
                         </td>
                         <td>
                           <b>{{s.status}}</b>

--- a/src/app/components/layout/navbar/navbar.component.html
+++ b/src/app/components/layout/navbar/navbar.component.html
@@ -154,7 +154,7 @@
                           <span class="icon" [ngClass]="applyServiceStatusCustomCss(s.status)">
                             <i class="fa fa-circle"></i>
                           </span>
-                          {{s.name}}&nbsp;
+                          {{s.name.substr(0,19)}}..&nbsp;
                         </td>
                         <td>
                           <b>{{s.status}}</b>


### PR DESCRIPTION
**Fixed Items**
1) Selecting item from plugin list adds description but make dialog resize issue

<img width="1011" alt="screen shot 2019-01-10 at 3 57 59 pm" src="https://user-images.githubusercontent.com/16384273/50962608-a38acd00-14f0-11e9-95f3-fd34faa8a943.png">


2) Message for no or only readonly configuration items on south and north wizard (Rare case, e.g. `game` plugin has one config item only and even that is  `readonly`)

&nbsp;&nbsp; <img width="1082" alt="screen shot 2019-01-10 at 3 58 31 pm" src="https://user-images.githubusercontent.com/16384273/50962676-cc12c700-14f0-11e9-9dbf-7ed49ed25cf0.png">

 