### PR TITLE
FOGL-2766: Add detailed documentation and required script for running-end-to-end-tests setup script

### DIFF
--- a/developers-guide.md
+++ b/developers-guide.md
@@ -31,16 +31,10 @@ Test report will be available in HTML format in `foglamp-gui/e2e-test-report/`; 
       $ sudo apt-get install google-chrome-stable
       ```
 
-  2. Clone foglamp-gui
+  2. Clone foglamp-gui & run e2e test
       ```
-      sudo git clone https://github.com/foglamp/foglamp-gui.git
-      ```
-  3. Inside foglamp-gui, run
-      ```
-      sudo yarn
-      ```
-  4. To run e2e test, run
-      ```
+      $ sudo git clone https://github.com/foglamp/foglamp-gui.git
+      $ sudo yarn
       $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
       ``` 
 
@@ -55,20 +49,13 @@ Test report will be available in HTML format in `foglamp-gui/e2e-test-report/`; 
       >If installation fail because of missing `liberation-fonts` dependency. Download and install it first
       ```
       $ yum install liberation-fonts-1.07.2-16.el7.noarch.rpm
-      ``` 
-
-  2. Clone foglamp-gui
-      ```
-      sudo git clone https://github.com/foglamp/foglamp-gui.git
       ```
 
-  3. Inside foglamp-gui, run
-      ```
-      sudo yarn
-      ```
+  2. Clone foglamp-gui & run e2e test
 
-  4. To run e2e test, run
       ```
+      $ sudo git clone https://github.com/foglamp/foglamp-gui.git
+      $ sudo yarn
       $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
       ```
 

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -17,6 +17,32 @@ Run `yarn e2e` to execute the end-to-end tests via [Protractor](http://www.protr
 
 Test report will be available in HTML format in `foglamp-gui/e2e-test-report/`; Open `report.html` in your favorite browser!
 
+  #### Steps to run e2e test in CI environment on headless machine
+  
+  1. Install google-chrome-stable
+      ```
+      $ wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+      $ sudo yum -y install google-chrome-stable_current_x86_64.rpm
+      ```
+
+      >If installation fail because of missing `liberation-fonts` dependency. Download and install it first
+      ```
+      $ yum install liberation-fonts-1.07.2-16.el7.noarch.rpm
+      ``` 
+
+  2. Clone foglamp-gui
+      ```
+      sudo git clone https://github.com/foglamp/foglamp-gui.git
+      ```
+  3. Inside foglap-gui, run
+      ```
+      sudo yarn
+      ```
+  4. To run e2e test, run
+      ```
+      $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
+      ```
+
 > Before running the tests make sure app is able to communicate with the FogLAMP REST Server API. Put the REST API info in `e2e/environment.ts`.
 
 ## REST API URL Configuration:

--- a/developers-guide.md
+++ b/developers-guide.md
@@ -17,8 +17,35 @@ Run `yarn e2e` to execute the end-to-end tests via [Protractor](http://www.protr
 
 Test report will be available in HTML format in `foglamp-gui/e2e-test-report/`; Open `report.html` in your favorite browser!
 
-  #### Steps to run e2e test in CI environment on headless machine
-  
+> Before running the tests make sure app is able to communicate with the FogLAMP REST Server API. Put the REST API info in `e2e/environment.ts`.
+
+### Steps to run e2e test in CI environment on headless machine
+
+#### Installation step on Ubuntu
+
+  1. Install google-chrome-stable
+      ```
+      $ wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+      $  echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | sudo tee /etc/apt/sources.list.d/google-chrome.list
+      $ sudo apt-get update
+      $ sudo apt-get install google-chrome-stable
+      ```
+
+  2. Clone foglamp-gui
+      ```
+      sudo git clone https://github.com/foglamp/foglamp-gui.git
+      ```
+  3. Inside foglamp-gui, run
+      ```
+      sudo yarn
+      ```
+  4. To run e2e test, run
+      ```
+      $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
+      ``` 
+
+#### Installation step on RHEL/CentOS machine
+
   1. Install google-chrome-stable
       ```
       $ wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
@@ -34,16 +61,16 @@ Test report will be available in HTML format in `foglamp-gui/e2e-test-report/`; 
       ```
       sudo git clone https://github.com/foglamp/foglamp-gui.git
       ```
-  3. Inside foglap-gui, run
+
+  3. Inside foglamp-gui, run
       ```
       sudo yarn
       ```
+
   4. To run e2e test, run
       ```
       $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
       ```
-
-> Before running the tests make sure app is able to communicate with the FogLAMP REST Server API. Put the REST API info in `e2e/environment.ts`.
 
 ## REST API URL Configuration:
 

--- a/protractor_ci.conf.js
+++ b/protractor_ci.conf.js
@@ -1,0 +1,43 @@
+// Protractor configuration file, see link for more information
+// https://github.com/angular/protractor/blob/master/lib/config.ts
+
+const { SpecReporter } = require('jasmine-spec-reporter');
+
+exports.config = {
+  allScriptsTimeout: 11000,
+  specs: [
+    './e2e/**/*.e2e-*.ts'
+  ],
+  capabilities: {
+    'browserName': 'chrome',
+    chromeOptions: {
+        args: ['--headless', '--disable-gpu', '--no-sandbox','--disable-browser-side-navigation', '--disable-extensions', '--disable-dev-shm-usage', '--window-size=1800,1000', '--test-type=ui', '--start-maximized']
+    }
+  },
+  // chromeDriver: './node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver',
+  directConnect: true,
+  baseUrl: 'http://localhost:4200/',
+  framework: 'jasmine',
+  jasmineNodeOpts: {
+    showColors: true,
+    defaultTimeoutInterval: 300000,
+    print: function () { }
+  },
+  onPrepare() {
+    // browser.driver.manage().timeouts().setScriptTimeout(60000);
+    var HtmlReporter = require('protractor-beautiful-reporter');
+    // Add a screenshot reporter and store screenshots to `/e2e-test-report`:
+      jasmine.getEnv().addReporter(new HtmlReporter({
+         baseDirectory: 'e2e-test-report',
+         jsonsSubfolder: 'json',
+         screenshotsSubfolder: 'screenshots',
+         takeScreenShotsOnlyForFailedSpecs: true,
+         preserveDirectory: false
+      }).getJasmine2Reporter());
+
+    require('ts-node').register({
+      project: 'e2e/tsconfig.e2e.json'
+    });
+    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
+  }
+};

--- a/protractor_ci.conf.js
+++ b/protractor_ci.conf.js
@@ -14,7 +14,6 @@ exports.config = {
         args: ['--headless', '--disable-gpu', '--no-sandbox','--disable-browser-side-navigation', '--disable-extensions', '--disable-dev-shm-usage', '--window-size=1800,1000', '--test-type=ui', '--start-maximized']
     }
   },
-  // chromeDriver: './node_modules/protractor/node_modules/webdriver-manager/selenium/chromedriver',
   directConnect: true,
   baseUrl: 'http://localhost:4200/',
   framework: 'jasmine',
@@ -24,7 +23,6 @@ exports.config = {
     print: function () { }
   },
   onPrepare() {
-    // browser.driver.manage().timeouts().setScriptTimeout(60000);
     var HtmlReporter = require('protractor-beautiful-reporter');
     // Add a screenshot reporter and store screenshots to `/e2e-test-report`:
       jasmine.getEnv().addReporter(new HtmlReporter({


### PR DESCRIPTION
#### Steps to run e2e test in CI environment on headless machine

  1. Install google-chrome-stable
      ```
      $ wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
      $ sudo yum -y install google-chrome-stable_current_x86_64.rpm
      ```

      >If installation fail because of missing `liberation-fonts` dependency. Download and install it first
      ```
      $ yum install liberation-fonts-1.07.2-16.el7.noarch.rpm
      ``` 
  2. Clone foglamp-gui
      ```
      sudo git clone https://github.com/foglamp/foglamp-gui.git
      ```
  3. Inside foglap-gui, run
      ```
      sudo yarn
      ```
  4. To run e2e test, run
      ```
      $ sudo yarn e2e --protractor-config=protractor_ci.conf.js
      ```