### PR TITLE
FOGL-2903: Plugin name and version on south page

### DIFF
--- a/src/app/components/core/south/south.component.html
+++ b/src/app/components/core/south/south.component.html
@@ -33,6 +33,8 @@
                 <tr>
                   <th class="align-th">Name</th>
                   <th class="align-th">Status</th>
+                  <th class="align-th">Plugin</th>
+                  <th class="align-th">Version</th>
                   <th class="align-th">
                     <table class="table is-responsive">
                       <tr>
@@ -59,6 +61,12 @@
                         <span *ngIf="svc.status == 'unresponsive'" class="tag is-warning">{{svc.status}}</span>
                       </ng-container>
                     </div>
+                  </td>
+                  <td class="align-content">
+                      {{svc.plugin.name}}
+                  </td>
+                  <td class="align-content">
+                      {{svc.plugin.version}}
                   </td>
                   <td class="align-content">
                     <table class="table is-narrow is-responsive">


### PR DESCRIPTION
Test with [foglamp/FogLAMP/pull/1591](https://github.com/foglamp/FogLAMP/pull/1591) [merged into develop]

<img width="965" alt="Screen Shot 2019-06-21 at 4 23 56 PM" src="https://user-images.githubusercontent.com/16384273/59918493-81ec2500-9442-11e9-9109-cb930fa856c1.png">
