### PR TITLE
FOGL-2911: Asset graph space usage

### DIFF
--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.css
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.css
@@ -5,6 +5,7 @@
 @media screen and (min-width: 769px) {
   .modal-card {
     width: 70%;
+    min-height: 60%;
   }
 }
 
@@ -16,6 +17,10 @@
   }
   .summary {
     width: 736px;
+  }
+  .dropdown-content {
+    max-height: 10em;
+    overflow: auto;
   }
 }
 

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.css
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.css
@@ -5,7 +5,6 @@
 @media screen and (min-width: 769px) {
   .modal-card {
     width: 70%;
-    min-height: 60%;
   }
 }
 
@@ -17,10 +16,6 @@
   }
   .summary {
     width: 736px;
-  }
-  .dropdown-content {
-    max-height: 10em;
-    overflow: auto;
   }
 }
 
@@ -50,4 +45,8 @@ tbody {
 
 .app-loading {
   min-height: 50vh;
+}
+
+.overflow {
+  overflow: visible;
 }

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -40,7 +40,7 @@
             </div>
           </div>
         </div>
-        <div class="column">
+        <div class="column" *ngIf="!isSpectrum && !showGraphSpinner">
           <a class="button is-small is-text"
             (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
         </div>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -1,6 +1,6 @@
 <div id="chart_modal" class="modal">
   <div class="modal-background"></div>
-  <div class="modal-card animated fadeIn">
+  <div class="modal-card animated fadeIn" [ngClass]="{overflow: timeDropDownOpened}">
     <header class="modal-card-head">
       <p class="modal-card-title is-size-5">{{assetCode}}
       </p>
@@ -8,7 +8,7 @@
         <button class="delete" aria-label="close" (click)="toggleModal(false)"></button>
       </div>
     </header>
-    <section class="modal-card-body">
+    <section class="modal-card-body" [ngClass]="{overflow: timeDropDownOpened}">
       <div class="columns">
         <div class="column is-2">
           <div id="time-dropdown" class="dropdown is-left">
@@ -126,8 +126,8 @@
           </ng-container>
         </ng-container>
       </ng-container>
-      <p *ngIf='showSummary && !showGraph' class="help"> Summary Not Available </p>
-      <p *ngIf='!showSummary && !showGraph' class="help"> Graph Not Available </p>
+      <p *ngIf='showSummary && !showGraph' class="help has-text-centered"> Summary Not Available </p>
+      <p *ngIf='!showSummary && !showGraph' class="help has-text-centered"> Graph Not Available </p>
     </section>
   </div>
 </div>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -41,80 +41,88 @@
               </div>
             </div>
           </div>
-        </div>
-        <ng-container *ngIf="showSummarySpinner">
-          <div class="app-loading">
-            &nbsp;
-            <svg class="spinner animated fadeIn fadeOut" viewBox="0 0 100 100">
-              <circle class="path" cx="50%" cy="50%" r="10" fill="none" stroke-width="2" stroke-miterlimit="10" />
-            </svg>
+          <div class="column">
+            <a class="button is-small is-text" (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
           </div>
-        </ng-container>
-        <div [ngClass]="{'summary': buttonText !== ''}" class="animated fadeIn" *ngIf="!showSummarySpinner">
-          <table class="table is-responsive is-borderless">
-            <tbody>
-              <tr [ngClass]="{'animated fadeInDown': autoRefresh === false}"
-                *ngFor="let asset of assetReadingSummary  | slice:0:summaryLimit">
-                <td>
-                  <span>
-                    <b><small>{{asset.name}}</small></b>
-                  </span>
-                </td>
-                <ng-container *ngFor="let reading of asset.value">
+        </div>
+        <ng-container *ngIf="showSummary">
+          <ng-container *ngIf="showSummarySpinner">
+            <div class="app-loading">
+              &nbsp;
+              <svg class="spinner animated fadeIn fadeOut" viewBox="0 0 100 100">
+                <circle class="path" cx="50%" cy="50%" r="10" fill="none" stroke-width="2" stroke-miterlimit="10" />
+              </svg>
+            </div>
+          </ng-container>
+          <div [ngClass]="{'summary': buttonText !== ''}" class="animated fadeIn" *ngIf="!showSummarySpinner">
+            <table class="table is-responsive is-borderless">
+              <tbody>
+                <tr [ngClass]="{'animated fadeInDown': autoRefresh === false}"
+                  *ngFor="let asset of assetReadingSummary  | slice:0:summaryLimit">
                   <td>
-                    <div class="tags has-addons">
-                      <span class="tag is-light"> Avg </span>
-                      <span class="tag is-info">{{isNumber(reading.average)
+                    <span>
+                      <b><small>{{asset.name}}</small></b>
+                    </span>
+                  </td>
+                  <ng-container *ngFor="let reading of asset.value">
+                    <td>
+                      <div class="tags has-addons">
+                        <span class="tag is-light"> Avg </span>
+                        <span class="tag is-info">{{isNumber(reading.average)
                         ?
                         roundTo(reading.average,
                         5) : reading.average }}
-                      </span>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="tags has-addons">
-                      <span class="tag is-light"> Min </span>
-                      <span class="tag is-info">{{isNumber(reading.min) ?
+                        </span>
+                      </div>
+                    </td>
+                    <td>
+                      <div class="tags has-addons">
+                        <span class="tag is-light"> Min </span>
+                        <span class="tag is-info">{{isNumber(reading.min) ?
                         roundTo(reading.min, 5) : reading.min}}</span>
-                    </div>
-                  </td>
-                  <td>
-                    <div class="tags has-addons">
-                      <span class="tag is-light"> Max </span>
-                      <span class="tag is-info">{{isNumber(reading.max) ?
+                      </div>
+                    </td>
+                    <td>
+                      <div class="tags has-addons">
+                        <span class="tag is-light"> Max </span>
+                        <span class="tag is-info">{{isNumber(reading.max) ?
                         roundTo(reading.max, 5): reading.max}}</span>
-                    </div>
-                  </td>
-                </ng-container>
-              </tr>
-              <tr *ngIf="buttonText !== ''">
-                <td><a class="button is-small is-text" (click)="showAll()">{{buttonText}}</a></td>
-                <td></td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-        <ng-container *ngIf="showGraphSpinner">
-          <div class="app-loading">
-            &nbsp;
-            <svg class="spinner animated fadeIn fadeOut" viewBox="0 0 100 100">
-              <circle class="path" cx="50%" cy="50%" r="10" fill="none" stroke-width="2" stroke-miterlimit="10" />
-            </svg>
+                      </div>
+                    </td>
+                  </ng-container>
+                </tr>
+                <tr *ngIf="buttonText !== ''">
+                  <td><a class="button is-small is-text" (click)="showAll()">{{buttonText}}</a></td>
+                  <td></td>
+                </tr>
+              </tbody>
+            </table>
           </div>
         </ng-container>
-        <ng-container *ngIf="!isSpectrum">
-          <app-chart *ngIf="!showGraphSpinner" class="chart-container animated fadeIn" [type]="assetChartType"
-            [data]="assetReadingValues" [options]="assetChartOptions" #assetChart></app-chart>
-        </ng-container>
-        <ng-container *ngIf="isSpectrum">
-          <plotly-plot *ngIf="!showGraphSpinner" [data]="polyGraphData.data" [layout]="polyGraphData.layout"
-            [config]="{displayModeBar: false}">
-          </plotly-plot>
-        </ng-container>
+        <ng-container *ngIf="!showSummary">
+          <ng-container *ngIf="showGraphSpinner">
+            <div class="app-loading">
+              &nbsp;
+              <svg class="spinner animated fadeIn fadeOut" viewBox="0 0 100 100">
+                <circle class="path" cx="50%" cy="50%" r="10" fill="none" stroke-width="2" stroke-miterlimit="10" />
+              </svg>
+            </div>
+          </ng-container>
+          <ng-container *ngIf="!isSpectrum">
+            <app-chart *ngIf="!showGraphSpinner" class="chart-container animated fadeIn" [type]="assetChartType"
+              [data]="assetReadingValues" [options]="assetChartOptions" #assetChart></app-chart>
+          </ng-container>
+          <ng-container *ngIf="isSpectrum">
+            <plotly-plot *ngIf="!showGraphSpinner" [data]="polyGraphData.data" [layout]="polyGraphData.layout"
+              [config]="{displayModeBar: false}">
+            </plotly-plot>
+          </ng-container>
 
-        <ng-container *ngIf="excludedReadingsList.length > 0">
-          <p class="help"> * Excluded <u>{{excludedReadingsList.toString().replace(',' , ', ')}}</u> having non-numeric
-            readings </p>
+          <ng-container *ngIf="excludedReadingsList.length > 0">
+            <p class="help"> * Excluded <u>{{excludedReadingsList.toString().replace(',' , ', ')}}</u> having
+              non-numeric
+              readings </p>
+          </ng-container>
         </ng-container>
       </ng-container>
       <p *ngIf='!showGraph' class="help"> Graph Not Available </p>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -9,43 +9,43 @@
       </div>
     </header>
     <section class="modal-card-body">
-      <ng-container *ngIf='showGraph'>
-        <div class="columns">
-          <div class="column is-2">
-            <div id="time-dropdown" class="dropdown is-left">
-              <div class="dropdown-trigger">
-                <button class="button is-rounded is-small" aria-haspopup="true" aria-controls="dropdown-menu"
-                  (click)=toggleDropdown()>
-                  <span *ngIf="optedTime == 60">1 minute</span>
-                  <span *ngIf="optedTime == 300">5 minutes</span>
-                  <span *ngIf="optedTime == 600">10 minutes</span>
-                  <span *ngIf="optedTime == 1800">30 minutes</span>
-                  <span *ngIf="optedTime == 3600">1 hour</span>
-                  <span *ngIf="optedTime == 28800">8 hour</span>
-                  <span *ngIf="optedTime == 86400">1 day</span>
-                  <span class="icon is-small">
-                    <i class="fa fa-angle-down" aria-hidden="true"></i>
-                  </span>
-                </button>
-              </div>
-              <div class="dropdown-menu" id="dropdown-menu" role="menu">
-                <div class="dropdown-content">
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(60)">1 minute</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(300)">5 minutes</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(600)">10 minutes</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(1800)">30 minutes</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(3600)">1 hour</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(28800)">8 hour</a>
-                  <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(86400)">1 day</a>
-                </div>
+      <div class="columns">
+        <div class="column is-2">
+          <div id="time-dropdown" class="dropdown is-left">
+            <div class="dropdown-trigger">
+              <button class="button is-rounded is-small" aria-haspopup="true" aria-controls="dropdown-menu"
+                (click)=toggleDropdown()>
+                <span *ngIf="optedTime == 60">1 minute</span>
+                <span *ngIf="optedTime == 300">5 minutes</span>
+                <span *ngIf="optedTime == 600">10 minutes</span>
+                <span *ngIf="optedTime == 1800">30 minutes</span>
+                <span *ngIf="optedTime == 3600">1 hour</span>
+                <span *ngIf="optedTime == 28800">8 hour</span>
+                <span *ngIf="optedTime == 86400">1 day</span>
+                <span class="icon is-small">
+                  <i class="fa fa-angle-down" aria-hidden="true"></i>
+                </span>
+              </button>
+            </div>
+            <div class="dropdown-menu" id="dropdown-menu" role="menu">
+              <div class="dropdown-content">
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(60)">1 minute</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(300)">5 minutes</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(600)">10 minutes</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(1800)">30 minutes</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(3600)">1 hour</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(28800)">8 hour</a>
+                <a class="dropdown-item" (click)="getTimeBasedAssetReadingsAndSummary(86400)">1 day</a>
               </div>
             </div>
           </div>
-          <div class="column">
-            <a class="button is-small is-text"
-              (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
-          </div>
         </div>
+        <div class="column">
+          <a class="button is-small is-text"
+            (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
+        </div>
+      </div>
+      <ng-container *ngIf='showGraph'>
         <ng-container *ngIf="showSummary">
           <ng-container *ngIf="showSummarySpinner">
             <div class="app-loading">
@@ -126,8 +126,8 @@
           </ng-container>
         </ng-container>
       </ng-container>
-      <p *ngIf='showSummary && assetReadingSummary.length === 0' class="help"> Summary Not Available </p>
-      <p *ngIf='!showGraph' class="help"> Graph Not Available </p>
+      <p *ngIf='showSummary && !showGraph' class="help"> Summary Not Available </p>
+      <p *ngIf='!showSummary && !showGraph' class="help"> Graph Not Available </p>
     </section>
   </div>
 </div>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.html
@@ -42,7 +42,8 @@
             </div>
           </div>
           <div class="column">
-            <a class="button is-small is-text" (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
+            <a class="button is-small is-text"
+              (click)="toggleSummaryGraph(showSummary)">{{toggleSummaryGraphButtonText}}</a>
           </div>
         </div>
         <ng-container *ngIf="showSummary">
@@ -125,6 +126,7 @@
           </ng-container>
         </ng-container>
       </ng-container>
+      <p *ngIf='showSummary && assetReadingSummary.length === 0' class="help"> Summary Not Available </p>
       <p *ngIf='!showGraph' class="help"> Graph Not Available </p>
     </section>
   </div>

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -36,7 +36,9 @@ export class ReadingsGraphComponent implements OnDestroy {
   public isSpectrum = false;
   public polyGraphData = {};
   public showSummary = false;
-  public toggleSummaryGraphButtonText = 'Show Summary';
+  public SHOW_SUMMARY_TEXT = 'Show Summary';
+  public SHOW_GRAPH_TEXT = 'Show Graph';
+  public toggleSummaryGraphButtonText = this.SHOW_SUMMARY_TEXT;
 
   @Output() notify: EventEmitter<any> = new EventEmitter<any>();
   @ViewChild('assetChart') assetChart: Chart;
@@ -85,7 +87,7 @@ export class ReadingsGraphComponent implements OnDestroy {
     this.excludedReadingsList = [];
     this.assetChartOptions = {};
     this.showSummary = false;
-    this.toggleSummaryGraphButtonText = 'Show summary';
+    this.toggleSummaryGraphButtonText = this.SHOW_SUMMARY_TEXT;
 
     sessionStorage.removeItem(this.assetCode);
 
@@ -132,9 +134,9 @@ export class ReadingsGraphComponent implements OnDestroy {
   toggleSummaryGraph(state: boolean) {
     this.showSummary = !state;
     if (!this.showSummary) {
-      this.toggleSummaryGraphButtonText = 'Show Summary';
+      this.toggleSummaryGraphButtonText = this.SHOW_SUMMARY_TEXT;
     } else {
-      this.toggleSummaryGraphButtonText = 'Show Graph';
+      this.toggleSummaryGraphButtonText = this.SHOW_GRAPH_TEXT;
     }
   }
 

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -200,7 +200,6 @@ export class ReadingsGraphComponent implements OnDestroy {
           };
         }).filter(value => value !== undefined);
         this.assetReadingSummary = orderBy(this.assetReadingSummary, ['name'], ['asc']);
-
         if (this.assetReadingSummary.length > 5 && this.summaryLimit === 5) {
           this.buttonText = 'Show All';
         }

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -36,6 +36,7 @@ export class ReadingsGraphComponent implements OnDestroy {
   public isSpectrum = false;
   public polyGraphData = {};
   public showSummary = false;
+  public timeDropDownOpened = false;
   public SHOW_SUMMARY_TEXT = 'Show Summary';
   public SHOW_GRAPH_TEXT = 'Show Graph';
   public toggleSummaryGraphButtonText = this.SHOW_SUMMARY_TEXT;
@@ -430,6 +431,11 @@ export class ReadingsGraphComponent implements OnDestroy {
   public toggleDropdown() {
     const dropDown = document.querySelector('#time-dropdown');
     dropDown.classList.toggle('is-active');
+    if (!dropDown.classList.contains('is-active')) {
+      this.timeDropDownOpened = false;
+    } else {
+      this.timeDropDownOpened = true;
+    }
   }
 
   public isNumber(val) {

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -35,6 +35,8 @@ export class ReadingsGraphComponent implements OnDestroy {
   public showSummarySpinner = true;
   public isSpectrum = false;
   public polyGraphData = {};
+  public showSummary = false;
+  public toggleSummaryGraphButtonText = 'Show Summary';
 
   @Output() notify: EventEmitter<any> = new EventEmitter<any>();
   @ViewChild('assetChart') assetChart: Chart;
@@ -82,6 +84,8 @@ export class ReadingsGraphComponent implements OnDestroy {
     this.showSummarySpinner = true;
     this.excludedReadingsList = [];
     this.assetChartOptions = {};
+    this.showSummary = false;
+    this.toggleSummaryGraphButtonText = 'Show summary';
 
     sessionStorage.removeItem(this.assetCode);
 
@@ -109,14 +113,29 @@ export class ReadingsGraphComponent implements OnDestroy {
     this.showSummarySpinner = true;
     this.optedTime = time;
     if (this.optedTime === 0) {
-      this.showAssetReadingsSummary(this.assetCode, this.DEFAULT_LIMIT, this.optedTime);
-      this.plotReadingsGraph(this.assetCode, this.DEFAULT_LIMIT, this.optedTime);
+      if (this.showSummary) {
+        this.showAssetReadingsSummary(this.assetCode, this.DEFAULT_LIMIT, this.optedTime);
+      } else {
+        this.plotReadingsGraph(this.assetCode, this.DEFAULT_LIMIT, this.optedTime);
+      }
     } else {
       this.limit = 0;
-      this.showAssetReadingsSummary(this.assetCode, this.limit, time);
-      this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+      if (this.showSummary) {
+        this.showAssetReadingsSummary(this.assetCode, this.limit, time);
+      } else {
+        this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+      }
     }
     this.toggleDropdown();
+  }
+
+  toggleSummaryGraph(state: boolean) {
+    state === true ? this.showSummary = false : this.showSummary = true;
+    if (!this.showSummary) {
+      this.toggleSummaryGraphButtonText = 'Show Summary';
+    } else {
+      this.toggleSummaryGraphButtonText = 'Show Graph';
+    }
   }
 
   public getAssetCode(assetCode) {
@@ -130,15 +149,21 @@ export class ReadingsGraphComponent implements OnDestroy {
     if (this.optedTime !== 0) {
       this.limit = 0;
       this.autoRefresh = false;
-      this.plotReadingsGraph(assetCode, this.limit, this.optedTime);
-      this.showAssetReadingsSummary(assetCode, this.limit, this.optedTime);
+      if (this.showSummary) {
+        this.showAssetReadingsSummary(assetCode, this.limit, this.optedTime);
+      } else {
+        this.plotReadingsGraph(assetCode, this.limit, this.optedTime);
+      }
     }
     interval(this.graphRefreshInterval)
       .takeWhile(() => this.isAlive) // only fires when component is alive
       .subscribe(() => {
         this.autoRefresh = true;
-        this.showAssetReadingsSummary(this.assetCode, this.limit, this.optedTime);
-        this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+        if (this.showSummary) {
+          this.showAssetReadingsSummary(this.assetCode, this.limit, this.optedTime);
+        } else {
+          this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+        }
       });
   }
 
@@ -150,8 +175,11 @@ export class ReadingsGraphComponent implements OnDestroy {
       this.limit = limit;
       this.optedTime = 0;
     }
-    this.showAssetReadingsSummary(this.assetCode, this.limit, this.optedTime);
-    this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+    if (!this.showSummary) {
+      this.showAssetReadingsSummary(this.assetCode, this.limit, this.optedTime);
+    } else {
+      this.plotReadingsGraph(this.assetCode, this.limit, this.optedTime);
+    }
   }
 
   public showAssetReadingsSummary(assetCode, limit: number = 0, time: number = 0) {

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -284,10 +284,10 @@ export class ReadingsGraphComponent implements OnDestroy {
                   ['0.8', 'rgba(101,201,96,1)'],
                   ['0.9', 'rgba(101,201,96,1)'],
                   ['1', 'rgba(253,231,37,1)']],
-                  colorbar: {
-                    tick0: 0,
-                    dtick: 5
-                  }
+                colorbar: {
+                  tick0: 0,
+                  dtick: 5
+                }
               },
             ],
             layout: {
@@ -350,6 +350,9 @@ export class ReadingsGraphComponent implements OnDestroy {
     };
     this.assetChartType = 'line';
     this.assetChartOptions = {
+      elements: {
+        point: { radius: 0 }
+      },
       scales: {
         xAxes: [{
           type: 'time',

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -190,8 +190,10 @@ export class ReadingsGraphComponent implements OnDestroy {
     this.assetService.getAllAssetSummary(assetCode, limit, time).subscribe(
       (data: any) => {
         this.assetReadingSummary = data.map(o => {
+          this.showGraph = true;
           const k = Object.keys(o)[0];
           if (isNaN(o[k]['max']) || isNaN(o[k]['min'])) {
+            this.showGraph = false;
             return;
           }
           return {

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -111,8 +111,6 @@ export class ReadingsGraphComponent implements OnDestroy {
   }
 
   getTimeBasedAssetReadingsAndSummary(time) {
-    this.showGraphSpinner = true;
-    this.showSummarySpinner = true;
     this.optedTime = time;
     if (this.optedTime === 0) {
       if (this.showSummary) {

--- a/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
+++ b/src/app/components/core/asset-readings/readings-graph/readings-graph.component.ts
@@ -130,7 +130,7 @@ export class ReadingsGraphComponent implements OnDestroy {
   }
 
   toggleSummaryGraph(state: boolean) {
-    state === true ? this.showSummary = false : this.showSummary = true;
+    this.showSummary = !state;
     if (!this.showSummary) {
       this.toggleSummaryGraphButtonText = 'Show Summary';
     } else {


### PR DESCRIPTION
1. Allowed toggle between summary and graph.
2. Removed dots in graph lines

<img width="904" alt="Screen Shot 2019-07-03 at 5 31 24 PM" src="https://user-images.githubusercontent.com/16384273/60589993-7ee52300-9db8-11e9-9a00-7169d00d300f.png">

<img width="908" alt="Screen Shot 2019-07-03 at 5 32 41 PM" src="https://user-images.githubusercontent.com/16384273/60590041-9e7c4b80-9db8-11e9-93b9-3403f7415f2f.png">

