### PR TITLE
FOGL-2933: Add support for password configuration items

### DIFF
--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.css
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.css
@@ -47,3 +47,7 @@
 #confirm-password {
   margin-top: 2%;
 }
+
+#confirm-password input{
+  padding-right: 2rem;
+}

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.css
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.css
@@ -43,3 +43,7 @@
 .tooltip.is-tooltip-multiline::before {
   min-width: 16rem !important;
 }
+
+#confirm-password {
+  margin-top: 2%;
+}

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -25,10 +25,20 @@
                       [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
                       [attr.maxLength]="configItem?.value?.length" />
 
-                    <input *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'"
-                      name="{{configItem.value.key}}" class="input is-fullwidth is-small" type="password"
-                      [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
-                      [attr.maxLength]="configItem?.value?.length" />
+                    <div class="field has-addons" *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'">
+                      <div class="control">
+                        <input name="{{configItem.value.key}}" class="input is-fullwidth is-small"
+                          type="{{typePassword? 'password' : 'text'}}" [ngModel]="setConfigValue(configItem.value)"
+                          [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length" />
+                      </div>
+                      <div class="control">
+                        <a class="button is-small">
+                          <span class="icon is-small" (click)="togglePassword()">
+                            <i class="{{typePassword? 'fa fa-eye-slash' : 'fa fa-eye'}}"></i>
+                          </span>
+                        </a>
+                      </div>
+                    </div>
 
                     <input *ngIf="getConfigAttributeType(configItem.value.type) === 'INTEGER'"
                       name="{{configItem.value.key}}" type="number" [value]='setConfigValue(configItem.value)'

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -29,7 +29,7 @@
                       <div class="control">
                         <input #pwd (input)="showConfirmPassword()" name="{{configItem.value.key}}"
                           class="input is-fullwidth is-small" type="password" onPaste="return false"
-                          (focus)="pwd.value=''" [ngModel]="setConfigValue(configItem.value)"
+                          (focus)="pwd.value=''; passwordMatched=false" [ngModel]="setConfigValue(configItem.value)"
                           [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length"
                           (ngModelChange)="checkPasswords(pwd.value, f?.controls['confirm-password']?.value)" />
                       </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -25,12 +25,13 @@
                       [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
                       [attr.maxLength]="configItem?.value?.length" />
 
-                    <div class="field has-addons" *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'">
+                    <div class="field has-addons " *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'">
                       <div class="control">
                         <input #pwd (input)="showConfirmPassword()" name="{{configItem.value.key}}"
                           class="input is-fullwidth is-small" type="password" onPaste="return false"
                           (focus)="pwd.value=''; passwordMatched=false" [ngModel]="setConfigValue(configItem.value)"
                           [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length"
+                          placeholder="password"
                           (ngModelChange)="checkPasswords(pwd.value, f?.controls['confirm-password']?.value)" />
                       </div>
                       <div class="control">

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -27,17 +27,41 @@
 
                     <div class="field has-addons" *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'">
                       <div class="control">
-                        <input name="{{configItem.value.key}}" class="input is-fullwidth is-small"
-                          type="{{typePassword? 'password' : 'text'}}" [ngModel]="setConfigValue(configItem.value)"
-                          [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length" />
+                        <input #pwd (input)="showConfirmPassword()" name="{{configItem.value.key}}"
+                          class="input is-fullwidth is-small" type="password"
+                          [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
+                          [attr.maxLength]="configItem?.value?.length"
+                          (ngModelChange)="checkPasswords(pwd.value, f?.controls['confirm-password']?.value)" />
                       </div>
                       <div class="control">
                         <a class="button is-small">
-                          <span class="icon is-small" (click)="togglePassword()">
-                            <i class="{{typePassword? 'fa fa-eye-slash' : 'fa fa-eye'}}"></i>
+                          <span class="icon is-small" (click)="togglePassword(pwd)">
+                            <i class="{{pwd.type === 'password'? 'fa fa-eye-slash' : 'fa fa-eye'}}"></i>
                           </span>
                         </a>
                       </div>
+                    </div>
+                    <div class="field"
+                      *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD' && passwordOnChangeFired">
+                      <div class="control">
+                        <div id="confirm-password" class="field has-addons">
+                          <div class="control">
+                            <input #confirmPwd name="confirm-password" class="input is-fullwidth is-small"
+                              type="password" [ngModel]="setConfigValue(configItem.value)"
+                              [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length"
+                              (ngModelChange)="checkPasswords(f?.controls[configItem.value.key]?.value, confirmPwd.value)" />
+                          </div>
+                          <div class="control">
+                            <a class="button is-small">
+                              <span class="icon is-small" (click)="togglePassword(confirmPwd)">
+                                <i class="{{confirmPwd.type === 'password' ? 'fa fa-eye-slash' : 'fa fa-eye'}}"></i>
+                              </span>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
+                      <p *ngIf="!passwordMatched" class="help is-danger">
+                        <sup>*</sup>Password mismatch</p>
                     </div>
 
                     <input *ngIf="getConfigAttributeType(configItem.value.type) === 'INTEGER'"

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.html
@@ -28,9 +28,9 @@
                     <div class="field has-addons" *ngIf="getConfigAttributeType(configItem.value.type) === 'PASSWORD'">
                       <div class="control">
                         <input #pwd (input)="showConfirmPassword()" name="{{configItem.value.key}}"
-                          class="input is-fullwidth is-small" type="password"
-                          [ngModel]="setConfigValue(configItem.value)" [value]='setConfigValue(configItem.value)'
-                          [attr.maxLength]="configItem?.value?.length"
+                          class="input is-fullwidth is-small" type="password" onPaste="return false"
+                          (focus)="pwd.value=''" [ngModel]="setConfigValue(configItem.value)"
+                          [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length"
                           (ngModelChange)="checkPasswords(pwd.value, f?.controls['confirm-password']?.value)" />
                       </div>
                       <div class="control">
@@ -47,16 +47,10 @@
                         <div id="confirm-password" class="field has-addons">
                           <div class="control">
                             <input #confirmPwd name="confirm-password" class="input is-fullwidth is-small"
-                              type="password" [ngModel]="setConfigValue(configItem.value)"
-                              [value]='setConfigValue(configItem.value)' [attr.maxLength]="configItem?.value?.length"
+                              onPaste="return false" type="password" [ngModel]="setConfigValue(confirmPwd.value)"
+                              [value]='setConfigValue(confirmPwd.value)' [attr.maxLength]="configItem?.value?.length"
+                              placeholder="confirm password"
                               (ngModelChange)="checkPasswords(f?.controls[configItem.value.key]?.value, confirmPwd.value)" />
-                          </div>
-                          <div class="control">
-                            <a class="button is-small">
-                              <span class="icon is-small" (click)="togglePassword(confirmPwd)">
-                                <i class="{{confirmPwd.type === 'password' ? 'fa fa-eye-slash' : 'fa fa-eye'}}"></i>
-                              </span>
-                            </a>
                           </div>
                         </div>
                       </div>

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -28,6 +28,7 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public hasEditableConfigItems = true;
   public fileContent = '';
   public fileName = '';
+  public typePassword = true;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -295,5 +296,9 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
       && this.useDeliveryProxy === 'false') {
       return 'false';
     }
+  }
+
+  togglePassword() {
+    this.typePassword = !this.typePassword;
   }
 }

--- a/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
+++ b/src/app/components/core/configuration-manager/view-config-item/view-config-item.component.ts
@@ -28,7 +28,8 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   public hasEditableConfigItems = true;
   public fileContent = '';
   public fileName = '';
-  public typePassword = true;
+  public passwordOnChangeFired = false;
+  public passwordMatched = true;
 
   constructor(private configService: ConfigurationService,
     private alertService: AlertService,
@@ -82,11 +83,15 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
   }
 
   public saveConfiguration(form: NgForm) {
-
     this.isValidForm = true;
-    if (!form.valid) {
+    if (!form.valid || !this.passwordMatched) {
       this.isValidForm = false;
       return;
+    }
+
+    if (this.passwordMatched) {
+      this.passwordOnChangeFired = false;
+      form.control.removeControl('confirm-password');
     }
 
     const formData = Object.keys(form.value).map(key => {
@@ -298,7 +303,18 @@ export class ViewConfigItemComponent implements OnInit, OnChanges {
     }
   }
 
-  togglePassword() {
-    this.typePassword = !this.typePassword;
+  showConfirmPassword() {
+    this.passwordOnChangeFired = true;
+  }
+
+  togglePassword(input: any): any {
+    input.type = input.type === 'password' ? 'text' : 'password';
+  }
+
+  checkPasswords(password: string, confirmPassword: string) {
+    this.passwordMatched = true;
+    if (password !== confirmPassword) {
+      this.passwordMatched = false;
+    }
   }
 }


### PR DESCRIPTION
FOGL-2933 - Fixed  Point:3
> Two input files should be created always, an X and X confirm. On save these should be checked to confirm they are the same. Only one is sent to the API. An error is generated if they differ.

<img width="660" alt="Screen Shot 2019-07-23 at 1 17 41 PM" src="https://user-images.githubusercontent.com/16384273/61692988-595e9000-ad4c-11e9-9dca-5e12c68b325e.png">

<img width="743" alt="Screen Shot 2019-07-23 at 1 17 03 PM" src="https://user-images.githubusercontent.com/16384273/61692998-60859e00-ad4c-11e9-8051-cd14c2d284d1.png">

<img width="698" alt="Screen Shot 2019-07-23 at 1 17 22 PM" src="https://user-images.githubusercontent.com/16384273/61693019-69766f80-ad4c-11e9-9d44-05010bb399c6.png">


