### PR TITLE
FOGL-3033 (gui) remove unwanted tab whitspaces from log text; removed hard-coded name

### DIFF
--- a/src/app/components/core/packages-log/packages-log.component.html
+++ b/src/app/components/core/packages-log/packages-log.component.html
@@ -24,7 +24,7 @@
               </small>
             </td>
             <td style="vertical-align: middle;">
-              {{ log.name ? log.name : 'update' }}
+              {{ log.name ? log.name : '' }}
             </td>
             <td>
               <a (click)="showLogs(log.filename)" class="button is-text">

--- a/src/app/components/core/packages-log/view-logs/view-logs.component.html
+++ b/src/app/components/core/packages-log/view-logs/view-logs.component.html
@@ -2,9 +2,7 @@
   <div class="modal-background"></div>
   <div class="modal-content">
     <div class="box">
-      <pre>
-        {{logText}}
-      </pre>
+      <pre>{{logText}}</pre>
     </div>
   </div>
   <button class="modal-close is-large" aria-label="close" (click)="toggleModal(false)"></button>


### PR DESCRIPTION
of command / action performed and show as received from API

Signed-off-by: Praveen Garg <praveen.garg@nerdapplabs.com>


Patch on https://github.com/foglamp/foglamp-gui/pull/490